### PR TITLE
Update kine version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	k8s.io/component-base v0.18.0
 )
 
-replace github.com/rancher/kine => github.com/canonical/kine v0.4.1-k8s-dqlite.1
+replace github.com/rancher/kine => github.com/canonical/kine v0.4.1-k8s-dqlite.2

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/canonical/go-dqlite v1.8.0/go.mod h1:MVgCUhFflG7GDAwb6q2CDp5kmdHyIX+XXkATDsiaDzw=
 github.com/canonical/go-dqlite v1.10.1-0.20211018012438-4123028456df h1:ePZa6Im11Y1fanhEWmubZrUUJTvcmx/mVDL4PWjvAXI=
 github.com/canonical/go-dqlite v1.10.1-0.20211018012438-4123028456df/go.mod h1:UuL9v+AE91/eXGgx/6XaO4Xrw10WRsflT03cnUIxTPc=
-github.com/canonical/kine v0.4.1-k8s-dqlite.1 h1:JgycDaytenrB511+mnzcXuFzz/pKktiDu7YB4SeVrcc=
-github.com/canonical/kine v0.4.1-k8s-dqlite.1/go.mod h1:cLSTFbvpmjXdj0Dd9Bsm5PIvwfliTobnY9JcTIftmKQ=
+github.com/canonical/kine v0.4.1-k8s-dqlite.2 h1:4yfjamPA6ey0n6ZNYhIvXpNM4IZApmuc4IAlt0isuaA=
+github.com/canonical/kine v0.4.1-k8s-dqlite.2/go.mod h1:cLSTFbvpmjXdj0Dd9Bsm5PIvwfliTobnY9JcTIftmKQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=


### PR DESCRIPTION
### Summary

Update Kine version to `v0.4.1-k8s-dqlite.2`, to include https://github.com/canonical/kine/pull/7

### Note

Only merge after https://github.com/canonical/kine/pull/7.