### PR TITLE
TLS dial ClientSessionCache size configuration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -32,13 +32,14 @@ import (
 )
 
 var opts = options.Options{
-	StorageDir:      "/var/tmp/k8s-dqlite",
-	ListenEp:        "tcp://127.0.0.1:12379",
-	EnableTLS:       true,
-	Debug:           false,
-	EnableProfiling: false,
-	ProfilingListen: "127.0.0.1:40000",
-	DiskMode:        false,
+	StorageDir:             "/var/tmp/k8s-dqlite",
+	ListenEp:               "tcp://127.0.0.1:12379",
+	EnableTLS:              true,
+	Debug:                  false,
+	EnableProfiling:        false,
+	ProfilingListen:        "127.0.0.1:40000",
+	DiskMode:               false,
+	ClientSessionCacheSize: 0,
 }
 
 // liteCmd represents the base command when called without any subcommands
@@ -65,6 +66,7 @@ var dqliteCmd = &cobra.Command{
 			opts.ListenEp,
 			opts.EnableTLS,
 			opts.DiskMode,
+			opts.ClientSessionCacheSize,
 		)
 		if err != nil {
 			log.Fatalf("Failed to start server: %s\n", err)
@@ -106,4 +108,5 @@ func init() {
 	dqliteCmd.Flags().BoolVar(&opts.EnableProfiling, "profiling", opts.EnableProfiling, "enable debug pprof endpoint")
 	dqliteCmd.Flags().StringVar(&opts.ProfilingListen, "profiling-listen", opts.ProfilingListen, "listen address for pprof endpoint")
 	dqliteCmd.Flags().BoolVar(&opts.DiskMode, "disk-mode", opts.DiskMode, "(experimental) run dqlite store in disk mode")
+	dqliteCmd.Flags().UintVar(&opts.ClientSessionCacheSize, "tls-client-session-cache-size", opts.ClientSessionCacheSize, "ClientCacheSession size for dial TLS config")
 }

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -18,11 +18,12 @@ package options
 
 // Options is the list of options for running k8s-dqlite.
 type Options struct {
-	StorageDir      string
-	ListenEp        string
-	EnableTLS       bool
-	Debug           bool
-	EnableProfiling bool
-	ProfilingListen string
-	DiskMode        bool
+	StorageDir             string
+	ListenEp               string
+	EnableTLS              bool
+	Debug                  bool
+	EnableProfiling        bool
+	ProfilingListen        string
+	DiskMode               bool
+	ClientSessionCacheSize uint
 }


### PR DESCRIPTION
### Summary

Make the ClientSessionCache configurable in the used TLS dial configuration. Setting a positive size should improve performance with TLS session resumption, but comes at the cost of being incompatible with previous go-dqlite versions.

### Testing

- (nodeA) Install MicroK8s on 1.26/stable
- (nodeB) Install MicroK8s on latest/edge with this build and --tls-client-session-cache-size=256
- Join nodeB to nodeA. The join process stalls, from the logs we observe that dqlite cannot communicate
- Remove the `--tls-client-session-cache-size` from nodeB, using the default size 0
- Join completes without issues

