### PR TITLE
Add metrics for operations and individual transactions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/server"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
@@ -25,6 +26,8 @@ var (
 	diskMode               bool
 	clientSessionCacheSize uint
 	minTLSVersion          string
+	enableMetrics          bool
+	metricsListenAddress   string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -41,7 +44,17 @@ var rootCmd = &cobra.Command{
 
 		if enableProfiling {
 			go func() {
+				logrus.WithField("address", profilingListenAddress).Print("Enable pprof endpoint")
 				http.ListenAndServe(profilingListenAddress, nil)
+			}()
+		}
+
+		if enableMetrics {
+			go func() {
+				logrus.WithField("address", metricsListenAddress).Print("Enable metrics endpoint")
+				mux := http.NewServeMux()
+				mux.Handle("/metrics", promhttp.Handler())
+				http.ListenAndServe(metricsListenAddress, mux)
 			}()
 		}
 
@@ -94,4 +107,6 @@ func init() {
 	rootCmd.Flags().BoolVar(&diskMode, "disk-mode", false, "(experimental) run dqlite store in disk mode")
 	rootCmd.Flags().UintVar(&clientSessionCacheSize, "tls-client-session-cache-size", 0, "ClientCacheSession size for dial TLS config")
 	rootCmd.Flags().StringVar(&minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version for dqlite endpoint (tls10|tls11|tls12|tls13). Default is tls12")
+	rootCmd.Flags().BoolVar(&enableMetrics, "metrics", true, "enable metrics endpoint")
+	rootCmd.Flags().StringVar(&metricsListenAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.2.1
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
@@ -42,7 +43,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -22,12 +22,6 @@ var (
 		SELECT MAX(rkv.id) AS id
 		FROM kine AS rkv`
 
-	compactRevSQL = `
-		SELECT crkv.prev_revision
-		FROM kine crkv
-		WHERE crkv.name = 'compact_rev_key'
-		ORDER BY crkv.id DESC LIMIT 1`
-
 	listSQL = fmt.Sprintf(`
 		SELECT %s
 		FROM kine AS kv
@@ -155,35 +149,6 @@ func q(sql, param string, numbered bool) string {
 		}
 		return param
 	})
-}
-
-// Migrate first checks that the old key_value table and new Kine table are
-// correctly sized, and if so, it performs row migration. It's a legacy method,
-// supporting MySQL and PGSql
-func (d *Generic) Migrate(ctx context.Context) {
-	var (
-		count     = 0
-		countKV   = d.queryRow(ctx, "SELECT COUNT(*) FROM key_value")
-		countKine = d.queryRow(ctx, "SELECT COUNT(*) FROM kine")
-	)
-
-	if err := countKV.Scan(&count); err != nil || count == 0 {
-		return
-	}
-
-	if err := countKine.Scan(&count); err != nil || count != 0 {
-		return
-	}
-
-	logrus.Infof("Migrating content from old table")
-	_, err := d.execute(ctx,
-		`INSERT INTO kine(deleted, create_revision, prev_revision, name, value, created, lease)
-					SELECT 0, 0, 0, kv.name, kv.value, 1, CASE WHEN kv.ttl > 0 THEN 15 ELSE 0 END
-					FROM key_value kv
-						WHERE kv.id IN (SELECT MAX(kvd.id) FROM key_value kvd GROUP BY kvd.name)`)
-	if err != nil {
-		logrus.Errorf("Row migrations failed: %v", err)
-	}
 }
 
 func openAndTest(driverName, dataSourceName string) (*sql.DB, error) {
@@ -343,12 +308,14 @@ func getPrefixRange(prefix string) (start, end string) {
 	return start, end
 }
 
-func (d *Generic) query(ctx context.Context, sql string, args ...interface{}) (rows *sql.Rows, err error) {
+func (d *Generic) query(ctx context.Context, txName, sql string, args ...interface{}) (rows *sql.Rows, err error) {
 	i := uint(0)
+	start := time.Now()
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("query (try: %d): %w", i, err)
 		}
+		recordOpResult(txName, err, start)
 	}()
 	strippedSQL := Stripped(sql)
 	for ; i < 500; i++ {
@@ -362,87 +329,47 @@ func (d *Generic) query(ctx context.Context, sql string, args ...interface{}) (r
 			time.Sleep(jitter.Deviation(nil, 0.3)(2 * time.Millisecond))
 			continue
 		}
+		recordTxResult(txName, err)
 		return rows, err
 	}
 	return
 }
 
-func (d *Generic) queryPrepared(ctx context.Context, sql string, prepared *sql.Stmt, args ...interface{}) (result *sql.Rows, err error) {
+func (d *Generic) queryPrepared(ctx context.Context, txName, sql string, prepared *sql.Stmt, args ...interface{}) (result *sql.Rows, err error) {
 	logrus.Tracef("QUERY %v : %s", args, Stripped(sql))
-	return prepared.QueryContext(ctx, args...)
+	start := time.Now()
+	r, err := prepared.QueryContext(ctx, args...)
+	recordOpResult(txName, err, start)
+	recordTxResult(txName, err)
+	return r, err
 }
 
-func (d *Generic) queryRow(ctx context.Context, sql string, args ...interface{}) (result *sql.Row) {
+func (d *Generic) queryRow(ctx context.Context, txName, sql string, args ...interface{}) (result *sql.Row) {
 	logrus.Tracef("QUERY ROW %v : %s", args, Stripped(sql))
-	return d.DB.QueryRowContext(ctx, sql, args...)
+	start := time.Now()
+	r := d.DB.QueryRowContext(ctx, sql, args...)
+	recordOpResult(txName, r.Err(), start)
+	recordTxResult(txName, r.Err())
+	return r
 }
 
-func (d *Generic) queryRowPrepared(ctx context.Context, sql string, prepared *sql.Stmt, args ...interface{}) (result *sql.Row) {
+func (d *Generic) queryRowPrepared(ctx context.Context, txName, sql string, prepared *sql.Stmt, args ...interface{}) (result *sql.Row) {
 	logrus.Tracef("QUERY ROW %v : %s", args, Stripped(sql))
-	return prepared.QueryRowContext(ctx, args...)
+	start := time.Now()
+	r := prepared.QueryRowContext(ctx, args...)
+	recordOpResult(txName, r.Err(), start)
+	recordTxResult(txName, r.Err())
+	return r
 }
 
-func (d *Generic) queryInt64(ctx context.Context, sql string, args ...interface{}) (n int64, err error) {
+func (d *Generic) executePrepared(ctx context.Context, txName, sql string, prepared *sql.Stmt, args ...interface{}) (result sql.Result, err error) {
 	i := uint(0)
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("query int64 (try: %d): %w", i, err)
-		}
-	}()
-	strippedSQL := Stripped(sql)
-
-	for ; i < 500; i++ {
-		if i > 2 {
-			logrus.Debugf("QUERY INT64 (try: %d) %v : %s", i, args, strippedSQL)
-		} else {
-			logrus.Tracef("QUERY INT64 (try: %d) %v : %s", i, args, strippedSQL)
-		}
-		row := d.DB.QueryRowContext(ctx, sql, args...)
-		err = row.Scan(&n)
-		if err != nil && d.Retry != nil && d.Retry(err) {
-			time.Sleep(jitter.Deviation(nil, 0.3)(2 * time.Millisecond))
-			continue
-		}
-		return n, err
-	}
-	return
-}
-
-func (d *Generic) execute(ctx context.Context, sql string, args ...interface{}) (result sql.Result, err error) {
-	i := uint(0)
+	start := time.Now()
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("exec (try: %d): %w", i, err)
 		}
-	}()
-	if d.LockWrites {
-		d.Lock()
-		defer d.Unlock()
-	}
-
-	strippedSQL := Stripped(sql)
-	for ; i < 500; i++ {
-		if i > 2 {
-			logrus.Debugf("EXEC (try: %d) %v : %s", i, args, strippedSQL)
-		} else {
-			logrus.Tracef("EXEC (try: %d) %v : %s", i, args, strippedSQL)
-		}
-		result, err = d.DB.ExecContext(ctx, sql, args...)
-		if err != nil && d.Retry != nil && d.Retry(err) {
-			time.Sleep(jitter.Deviation(nil, 0.3)(2 * time.Millisecond))
-			continue
-		}
-		return result, err
-	}
-	return
-}
-
-func (d *Generic) executePrepared(ctx context.Context, sql string, prepared *sql.Stmt, args ...interface{}) (result sql.Result, err error) {
-	i := uint(0)
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("exec (try: %d): %w", i, err)
-		}
+		recordOpResult(txName, err, start)
 	}()
 	if d.LockWrites {
 		d.Lock()
@@ -461,6 +388,7 @@ func (d *Generic) executePrepared(ctx context.Context, sql string, prepared *sql
 			time.Sleep(jitter.Deviation(nil, 0.3)(2 * time.Millisecond))
 			continue
 		}
+		recordTxResult(txName, err)
 		return result, err
 	}
 	return
@@ -468,8 +396,17 @@ func (d *Generic) executePrepared(ctx context.Context, sql string, prepared *sql
 
 func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) {
 	var compact, target sql.NullInt64
+	start := time.Now()
+	var err error
+	defer func() {
+		if err == sql.ErrNoRows {
+			err = nil
+		}
+		recordOpResult("revision_interval_sql", err, start)
+		recordTxResult("revision_interval_sql", err)
+	}()
 	row := d.DB.QueryRow(revisionIntervalSQL)
-	err := row.Scan(&compact, &target)
+	err = row.Scan(&compact, &target)
 	if err == sql.ErrNoRows {
 		return 0, 0, nil
 	}
@@ -478,16 +415,16 @@ func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) 
 }
 
 func (d *Generic) SetCompactRevision(ctx context.Context, revision int64) error {
-	_, err := d.executePrepared(ctx, d.UpdateCompactSQL, d.updateCompactSQLPrepared, revision)
+	_, err := d.executePrepared(ctx, "update_compact_sql", d.UpdateCompactSQL, d.updateCompactSQLPrepared, revision)
 	return err
 }
 
 func (d *Generic) GetRevision(ctx context.Context, revision int64) (*sql.Rows, error) {
-	return d.queryPrepared(ctx, d.GetRevisionSQL, d.getRevisionSQLPrepared, revision)
+	return d.queryPrepared(ctx, "get_revision_sql", d.GetRevisionSQL, d.getRevisionSQLPrepared, revision)
 }
 
 func (d *Generic) DeleteRevision(ctx context.Context, revision int64) error {
-	_, err := d.executePrepared(ctx, d.DeleteSQL, d.deleteSQLPrepared, revision)
+	_, err := d.executePrepared(ctx, "delete_sql", d.DeleteSQL, d.deleteSQLPrepared, revision)
 	return err
 }
 
@@ -498,7 +435,7 @@ func (d *Generic) ListCurrent(ctx context.Context, prefix string, limit int64, i
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}
 
-	return d.query(ctx, sql, start, end, includeDeleted)
+	return d.query(ctx, "get_current_sql", sql, start, end, includeDeleted)
 }
 
 func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted bool) (*sql.Rows, error) {
@@ -508,14 +445,14 @@ func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revi
 		if limit > 0 {
 			sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 		}
-		return d.query(ctx, sql, start, end, revision, includeDeleted)
+		return d.query(ctx, "list_revision_start_sql", sql, start, end, revision, includeDeleted)
 	}
 
 	sql := d.GetRevisionAfterSQL
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}
-	return d.query(ctx, sql, start, end, revision, startKey, revision, includeDeleted)
+	return d.query(ctx, "get_revision_after_sql", sql, start, end, revision, startKey, revision, includeDeleted)
 }
 
 func (d *Generic) Count(ctx context.Context, prefix string) (int64, int64, error) {
@@ -526,7 +463,7 @@ func (d *Generic) Count(ctx context.Context, prefix string) (int64, int64, error
 
 	start, end := getPrefixRange(prefix)
 
-	row := d.queryRowPrepared(ctx, d.CountSQL, d.countSQLPrepared, start, end, false)
+	row := d.queryRowPrepared(ctx, "count_sql", d.CountSQL, d.countSQLPrepared, start, end, false)
 	err := row.Scan(&rev, &id)
 
 	return rev.Int64, id, err
@@ -534,7 +471,7 @@ func (d *Generic) Count(ctx context.Context, prefix string) (int64, int64, error
 
 func (d *Generic) CurrentRevision(ctx context.Context) (int64, error) {
 	var id int64
-	row := d.queryRow(ctx, revSQL)
+	row := d.queryRow(ctx, "rev_sql", revSQL)
 	err := row.Scan(&id)
 	if err == sql.ErrNoRows {
 		return 0, nil
@@ -548,7 +485,7 @@ func (d *Generic) AfterPrefix(ctx context.Context, prefix string, rev, limit int
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}
-	return d.query(ctx, sql, start, end, rev)
+	return d.query(ctx, "after_sql_prefix", sql, start, end, rev)
 }
 
 func (d *Generic) After(ctx context.Context, rev, limit int64) (*sql.Rows, error) {
@@ -556,11 +493,11 @@ func (d *Generic) After(ctx context.Context, rev, limit int64) (*sql.Rows, error
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}
-	return d.query(ctx, sql, rev)
+	return d.query(ctx, "after_sql", sql, rev)
 }
 
 func (d *Generic) Fill(ctx context.Context, revision int64) error {
-	_, err := d.executePrepared(ctx, d.FillSQL, d.fillSQLPrepared, revision, fmt.Sprintf("gap-%d", revision), 0, 1, 0, 0, 0, nil, nil)
+	_, err := d.executePrepared(ctx, "fill_sql", d.FillSQL, d.fillSQLPrepared, revision, fmt.Sprintf("gap-%d", revision), 0, 1, 0, 0, 0, nil, nil)
 	return err
 }
 
@@ -587,14 +524,14 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 	}
 
 	if d.LastInsertID {
-		row, err := d.executePrepared(ctx, d.InsertLastInsertIDSQL, d.insertLastInsertIDSQLPrepared, key, cVal, dVal, createRevision, previousRevision, ttl, value, prevValue)
+		row, err := d.executePrepared(ctx, "insert_last_insert_id_sql", d.InsertLastInsertIDSQL, d.insertLastInsertIDSQLPrepared, key, cVal, dVal, createRevision, previousRevision, ttl, value, prevValue)
 		if err != nil {
 			return 0, err
 		}
 		return row.LastInsertId()
 	}
 
-	row := d.queryRowPrepared(ctx, d.InsertSQL, d.insertSQLPrepared, key, cVal, dVal, createRevision, previousRevision, ttl, value, prevValue)
+	row := d.queryRowPrepared(ctx, "insert_sql", d.InsertSQL, d.insertSQLPrepared, key, cVal, dVal, createRevision, previousRevision, ttl, value, prevValue)
 	err = row.Scan(&id)
 
 	return id, err
@@ -605,7 +542,7 @@ func (d *Generic) GetSize(ctx context.Context) (int64, error) {
 		return 0, errors.New("driver does not support size reporting")
 	}
 	var size int64
-	row := d.queryRowPrepared(ctx, d.GetSizeSQL, d.getSizeSQLPrepared)
+	row := d.queryRowPrepared(ctx, "get_size_sql", d.GetSizeSQL, d.getSizeSQLPrepared)
 	if err := row.Scan(&size); err != nil {
 		return 0, err
 	}

--- a/pkg/kine/drivers/generic/metrics.go
+++ b/pkg/kine/drivers/generic/metrics.go
@@ -1,0 +1,48 @@
+package generic
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricsTxResult = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "k8s_dqlite_generic_tx_result",
+		Help: "Total number of individual database transactions by tx_name and result",
+	}, []string{"tx_name", "result"})
+	metricsOpResult = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "k8s_dqlite_generic_op_result",
+		Help: "Total number of database operations by tx_name and result",
+	}, []string{"tx_name", "result"})
+	metricsOpLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "k8s_dqlite_generic_op_latency",
+		Help:    "Transaction latency of database operations by tx_name and result",
+		Buckets: []float64{0, 0.05, 0.1, 0.3, 0.5, 1, 3, 5, 10},
+	}, []string{"tx_name", "result"})
+)
+
+func errorToResultLabel(err error) string {
+	if err != nil {
+		return "fail"
+	}
+	return "success"
+}
+
+func recordTxResult(txName string, err error) {
+	metricsTxResult.WithLabelValues(txName, errorToResultLabel(err)).Inc()
+}
+
+func recordOpResult(txName string, err error, startTime time.Time) {
+	resultLabel := errorToResultLabel(err)
+	metricsOpLatency.WithLabelValues(txName, resultLabel).Observe(float64(time.Since(startTime) / time.Second))
+	metricsOpResult.WithLabelValues(txName, resultLabel).Inc()
+}
+
+func init() {
+	prometheus.MustRegister(
+		metricsTxResult,
+		metricsOpResult,
+		metricsOpLatency,
+	)
+}


### PR DESCRIPTION
Replaces #52

- record a counter for successful/failed transactions and operations by tx_name and result
- record latency for database operations by tx_name and result
- remove unused functions
- add --metrics and --metrics-listen flags in k8s-dqlite command to expose metrics endpoint
- go mod tidy
