### PR TITLE
Make go-migrator a sub-command of k8s-dqlite

### DIFF
--- a/cmd/migrator.go
+++ b/cmd/migrator.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/canonical/k8s-dqlite/pkg/migrator"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	migratorCmdOpts struct {
+		endpoint string
+		mode     string
+		dbDir    string
+		debug    bool
+	}
+
+	migratorCmd = &cobra.Command{
+		Use:   "migrator",
+		Short: "Tool to migrate etcd to dqlite",
+		Long: `
+Copy data between etcd and kine (dqlite)
+
+		k8s-dqlite migrator --mode [backup-etcd|restore-etcd|backup-dqlite|restore-dqlite] --endpoint [etcd or kine endpoint] --db-dir [dir to store entries]
+
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if migratorCmdOpts.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+
+			ctx := cmd.Context()
+
+			logrus.WithFields(logrus.Fields{"mode": migratorCmdOpts.mode, "endpoint": migratorCmdOpts.endpoint, "dir": migratorCmdOpts.dbDir}).Print("Starting migrator")
+			switch migratorCmdOpts.mode {
+			case "backup", "backup-etcd":
+				if err := migrator.BackupEtcd(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.dbDir); err != nil {
+					logrus.WithError(err).Fatal("Failed to backup etcd")
+				}
+			case "restore", "restore-to-dqlite", "restore-dqlite":
+				if err := migrator.RestoreToDqlite(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.dbDir); err != nil {
+					logrus.WithError(err).Fatal("Failed to restore to etcd")
+				}
+			case "backup-dqlite":
+				if err := migrator.BackupDqlite(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.dbDir); err != nil {
+					logrus.WithError(err).Fatal("Failed to backup dqlite")
+				}
+			case "restore-to-etcd", "restore-etcd":
+				if err := migrator.RestoreToEtcd(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.dbDir); err != nil {
+					logrus.WithError(err).Fatal("Failed to restore etcd")
+				}
+			}
+		},
+	}
+)
+
+func init() {
+	migratorCmd.Flags().StringVar(&migratorCmdOpts.endpoint, "endpoint", "unix:///var/snap/microk8s/current/var/kubernetes/backend/kine.sock", "")
+	migratorCmd.Flags().StringVar(&migratorCmdOpts.mode, "mode", "backup", "")
+	migratorCmd.Flags().StringVar(&migratorCmdOpts.dbDir, "db-dir", "db", "")
+	migratorCmd.Flags().BoolVar(&migratorCmdOpts.debug, "debug", false, "")
+	rootCmd.AddCommand(migratorCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,76 +17,77 @@ import (
 )
 
 var (
-	storageDir             string
-	listenAddress          string
-	enableTLS              bool
-	debug                  bool
-	enableProfiling        bool
-	profilingListenAddress string
-	diskMode               bool
-	clientSessionCacheSize uint
-	minTLSVersion          string
-	enableMetrics          bool
-	metricsListenAddress   string
+	rootCmdOpts struct {
+		dir                    string
+		listen                 string
+		tls                    bool
+		debug                  bool
+		profiling              bool
+		profilingAddress       string
+		diskMode               bool
+		clientSessionCacheSize uint
+		minTLSVersion          string
+		metrics                bool
+		metricsAddress         string
+	}
+
+	rootCmd = &cobra.Command{
+		Use:   "k8s-dqlite",
+		Short: "Dqlite for Kubernetes",
+		Long:  `Kubernetes datastore based on dqlite`,
+		// Uncomment the following line if your bare application
+		// has an action associated with it:
+		Run: func(cmd *cobra.Command, args []string) {
+			if rootCmdOpts.debug {
+				logrus.SetLevel(logrus.TraceLevel)
+			}
+
+			if rootCmdOpts.profiling {
+				go func() {
+					logrus.WithField("address", rootCmdOpts.profilingAddress).Print("Enable pprof endpoint")
+					http.ListenAndServe(rootCmdOpts.profilingAddress, nil)
+				}()
+			}
+
+			if rootCmdOpts.metrics {
+				go func() {
+					logrus.WithField("address", rootCmdOpts.metricsAddress).Print("Enable metrics endpoint")
+					mux := http.NewServeMux()
+					mux.Handle("/metrics", promhttp.Handler())
+					http.ListenAndServe(rootCmdOpts.metricsAddress, mux)
+				}()
+			}
+
+			server, err := server.New(rootCmdOpts.dir, rootCmdOpts.listen, rootCmdOpts.tls, rootCmdOpts.diskMode, rootCmdOpts.clientSessionCacheSize, rootCmdOpts.minTLSVersion)
+			if err != nil {
+				logrus.WithError(err).Fatal("Failed to create server")
+			}
+
+			ctx, cancel := context.WithCancel(cmd.Context())
+			if err := server.Start(ctx); err != nil {
+				logrus.WithError(err).Fatal("Server terminated")
+			}
+
+			// Cancel context if we receive an exit signal
+			ch := make(chan os.Signal, 1)
+			signal.Notify(ch, unix.SIGPWR)
+			signal.Notify(ch, unix.SIGINT)
+			signal.Notify(ch, unix.SIGQUIT)
+			signal.Notify(ch, unix.SIGTERM)
+
+			<-ch
+			cancel()
+
+			// Create a separate context with 30 seconds to cleanup
+			stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			if err := server.Shutdown(stopCtx); err != nil {
+				logrus.WithError(err).Fatal("Failed to shutdown server")
+			}
+		},
+	}
 )
-
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "k8s-dqlite",
-	Short: "Dqlite for Kubernetes",
-	Long:  `Kubernetes datastore based on dqlite`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	Run: func(cmd *cobra.Command, args []string) {
-		if debug {
-			logrus.SetLevel(logrus.TraceLevel)
-		}
-
-		if enableProfiling {
-			go func() {
-				logrus.WithField("address", profilingListenAddress).Print("Enable pprof endpoint")
-				http.ListenAndServe(profilingListenAddress, nil)
-			}()
-		}
-
-		if enableMetrics {
-			go func() {
-				logrus.WithField("address", metricsListenAddress).Print("Enable metrics endpoint")
-				mux := http.NewServeMux()
-				mux.Handle("/metrics", promhttp.Handler())
-				http.ListenAndServe(metricsListenAddress, mux)
-			}()
-		}
-
-		server, err := server.New(storageDir, listenAddress, enableTLS, diskMode, clientSessionCacheSize, minTLSVersion)
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to create server")
-		}
-
-		ctx, cancel := context.WithCancel(cmd.Context())
-		if err := server.Start(ctx); err != nil {
-			logrus.WithError(err).Fatal("Server terminated")
-		}
-
-		// Cancel context if we receive an exit signal
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, unix.SIGPWR)
-		signal.Notify(ch, unix.SIGINT)
-		signal.Notify(ch, unix.SIGQUIT)
-		signal.Notify(ch, unix.SIGTERM)
-
-		<-ch
-		cancel()
-
-		// Create a separate context with 30 seconds to cleanup
-		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		if err := server.Shutdown(stopCtx); err != nil {
-			logrus.WithError(err).Fatal("Failed to shutdown server")
-		}
-	},
-}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the liteCmd.
@@ -98,15 +99,15 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&storageDir, "storage-dir", "/var/tmp/k8s-dqlite", "directory with the dqlite datastore")
-	rootCmd.Flags().StringVar(&listenAddress, "listen", "tcp://127.0.0.1:12379", "endpoint where dqlite should listen to")
-	rootCmd.Flags().BoolVar(&enableTLS, "enable-tls", true, "enable TLS")
-	rootCmd.Flags().BoolVar(&debug, "debug", false, "debug logs")
-	rootCmd.Flags().BoolVar(&enableProfiling, "profiling", false, "enable debug pprof endpoint")
-	rootCmd.Flags().StringVar(&profilingListenAddress, "profiling-listen", "127.0.0.1:4000", "listen address for pprof endpoint")
-	rootCmd.Flags().BoolVar(&diskMode, "disk-mode", false, "(experimental) run dqlite store in disk mode")
-	rootCmd.Flags().UintVar(&clientSessionCacheSize, "tls-client-session-cache-size", 0, "ClientCacheSession size for dial TLS config")
-	rootCmd.Flags().StringVar(&minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version for dqlite endpoint (tls10|tls11|tls12|tls13). Default is tls12")
-	rootCmd.Flags().BoolVar(&enableMetrics, "metrics", true, "enable metrics endpoint")
-	rootCmd.Flags().StringVar(&metricsListenAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
+	rootCmd.Flags().StringVar(&rootCmdOpts.dir, "storage-dir", "/var/tmp/k8s-dqlite", "directory with the dqlite datastore")
+	rootCmd.Flags().StringVar(&rootCmdOpts.listen, "listen", "tcp://127.0.0.1:12379", "endpoint where dqlite should listen to")
+	rootCmd.Flags().BoolVar(&rootCmdOpts.tls, "enable-tls", true, "enable TLS")
+	rootCmd.Flags().BoolVar(&rootCmdOpts.debug, "debug", false, "debug logs")
+	rootCmd.Flags().BoolVar(&rootCmdOpts.profiling, "profiling", false, "enable debug pprof endpoint")
+	rootCmd.Flags().StringVar(&rootCmdOpts.profilingAddress, "profiling-listen", "127.0.0.1:4000", "listen address for pprof endpoint")
+	rootCmd.Flags().BoolVar(&rootCmdOpts.diskMode, "disk-mode", false, "(experimental) run dqlite store in disk mode")
+	rootCmd.Flags().UintVar(&rootCmdOpts.clientSessionCacheSize, "tls-client-session-cache-size", 0, "ClientCacheSession size for dial TLS config")
+	rootCmd.Flags().StringVar(&rootCmdOpts.minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version for dqlite endpoint (tls10|tls11|tls12|tls13). Default is tls12")
+	rootCmd.Flags().BoolVar(&rootCmdOpts.metrics, "metrics", true, "enable metrics endpoint")
+	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
 }

--- a/pkg/kine/client/client.go
+++ b/pkg/kine/client/client.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type Value struct {
+	Key      []byte
+	Data     []byte
+	Modified int64
+}
+
+var (
+	ErrNotFound = errors.New("etcdwrapper: key not found")
+)
+
+type Client interface {
+	List(ctx context.Context, key string, rev int) ([]Value, error)
+	Get(ctx context.Context, key string) (Value, error)
+	Put(ctx context.Context, key string, value []byte) error
+	Create(ctx context.Context, key string, value []byte) error
+	Update(ctx context.Context, key string, revision int64, value []byte) error
+	Delete(ctx context.Context, key string, revision int64) error
+	Close() error
+}
+
+type client struct {
+	c *clientv3.Client
+}
+
+func New(config endpoint.ETCDConfig) (Client, error) {
+	tlsConfig, err := config.TLSConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := clientv3.New(clientv3.Config{
+		Endpoints:   config.Endpoints,
+		DialTimeout: 5 * time.Second,
+		TLS:         tlsConfig,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		c: c,
+	}, nil
+}
+
+func (c *client) List(ctx context.Context, key string, rev int) ([]Value, error) {
+	resp, err := c.c.Get(ctx, key, clientv3.WithPrefix(), clientv3.WithRev(int64(rev)))
+	if err != nil {
+		return nil, err
+	}
+
+	var vals []Value
+	for _, kv := range resp.Kvs {
+		vals = append(vals, Value{
+			Key:      kv.Key,
+			Data:     kv.Value,
+			Modified: kv.ModRevision,
+		})
+	}
+
+	return vals, nil
+}
+
+func (c *client) Get(ctx context.Context, key string) (Value, error) {
+	resp, err := c.c.Get(ctx, key)
+	if err != nil {
+		return Value{}, err
+	}
+
+	if len(resp.Kvs) == 1 {
+		return Value{
+			Key:      resp.Kvs[0].Key,
+			Data:     resp.Kvs[0].Value,
+			Modified: resp.Kvs[0].ModRevision,
+		}, nil
+	}
+
+	return Value{}, ErrNotFound
+}
+
+func (c *client) Put(ctx context.Context, key string, value []byte) error {
+	val, err := c.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+	if val.Modified == 0 {
+		return c.Create(ctx, key, value)
+	}
+	return c.Update(ctx, key, val.Modified, value)
+}
+
+func (c *client) Create(ctx context.Context, key string, value []byte) error {
+	resp, err := c.c.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+		Then(clientv3.OpPut(key, string(value))).
+		Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return fmt.Errorf("key exists")
+	}
+	return nil
+}
+
+func (c *client) Update(ctx context.Context, key string, revision int64, value []byte) error {
+	resp, err := c.c.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", revision)).
+		Then(clientv3.OpPut(key, string(value))).
+		Else(clientv3.OpGet(key)).
+		Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return fmt.Errorf("revision %d doesnt match", revision)
+	}
+	return nil
+}
+
+func (c *client) Delete(ctx context.Context, key string, revision int64) error {
+	resp, err := c.c.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", revision)).
+		Then(clientv3.OpDelete(key)).
+		Else(clientv3.OpGet(key)).
+		Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return fmt.Errorf("revision %d doesnt match", revision)
+	}
+	return nil
+}
+
+func (c *client) Close() error {
+	return c.c.Close()
+}

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -1,0 +1,148 @@
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/k8s-dqlite/pkg/kine/client"
+	kine_endpoint "github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
+	"github.com/sirupsen/logrus"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func keyFileName(dir string, index int) string {
+	return filepath.Join(dir, fmt.Sprintf("%d.key", index))
+}
+
+func dataFileName(dir string, index int) string {
+	return filepath.Join(dir, fmt.Sprintf("%d.data", index))
+}
+
+// BackupEtcd makes a back up of the contents of an etcd database into a filesystem directory.
+func BackupEtcd(ctx context.Context, endpoint, dir string) error {
+	client, err := clientv3.New(clientv3.Config{Endpoints: []string{endpoint}})
+	if err != nil {
+		return fmt.Errorf("failed to create etcd client: %w", err)
+	}
+	resp, err := client.Get(ctx, "", clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
+	if err != nil {
+		return fmt.Errorf("failed to list keys from etcd: %w", err)
+	}
+	client.Close()
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to backup directory: %w", err)
+	}
+	for idx, kv := range resp.Kvs {
+		logrus.WithFields(logrus.Fields{"index": idx, "key": string(kv.Key), "len": len(kv.Value)}).Print("Writing key")
+		if err := os.WriteFile(keyFileName(dir, idx), kv.Key, 0640); err != nil {
+			return fmt.Errorf("failed to write key file %d: %w", idx, err)
+		}
+		if err := os.WriteFile(dataFileName(dir, idx), kv.Value, 0640); err != nil {
+			return fmt.Errorf("failed to write data file %d: %w", idx, err)
+		}
+	}
+	return nil
+}
+
+// RestoreToDqlite restores database contents from backup directory to a k8s-dqlite database.
+func RestoreToDqlite(ctx context.Context, endpoint, dir string) error {
+	client, err := client.New(kine_endpoint.ETCDConfig{
+		Endpoints:   []string{endpoint},
+		LeaderElect: false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	defer client.Close()
+
+	idx := 0
+	for {
+		b, err := os.ReadFile(keyFileName(dir, idx))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to read key file: %w", err)
+			}
+			logrus.WithField("entries", idx).Print("Completed database restore")
+			return nil
+		}
+		key := string(b)
+
+		value, err := os.ReadFile(dataFileName(dir, idx))
+		if err != nil {
+			return fmt.Errorf("failed to read value file: %w", err)
+		}
+
+		log := logrus.WithFields(logrus.Fields{"index": idx, "key": key})
+		log.Debug("Restore key")
+		if err := putKey(ctx, client, key, value); err != nil {
+			log.Error("Failed to restore key")
+		}
+
+		idx++
+	}
+}
+
+// BackupDqlite makes a back up of the contents of a k8s-dqlite database into a filesystem directory.
+func BackupDqlite(ctx context.Context, endpoint, dir string) error {
+	client, err := client.New(kine_endpoint.ETCDConfig{Endpoints: []string{endpoint}})
+	if err != nil {
+		return fmt.Errorf("failed to create k8s-dqlite client: %w", err)
+	}
+	resp, err := client.List(ctx, "/", 0)
+	if err != nil {
+		return fmt.Errorf("failed to list keys from dqlite: %w", err)
+	}
+	client.Close()
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to backup directory: %w", err)
+	}
+	for idx, kv := range resp {
+		logrus.WithFields(logrus.Fields{"index": idx, "key": string(kv.Key), "len": len(kv.Data)}).Print("Writing key")
+		if err := os.WriteFile(keyFileName(dir, idx), kv.Key, 0640); err != nil {
+			return fmt.Errorf("failed to write key file %d: %w", idx, err)
+		}
+		if err := os.WriteFile(dataFileName(dir, idx), kv.Data, 0640); err != nil {
+			return fmt.Errorf("failed to write data file %d: %w", idx, err)
+		}
+	}
+	return nil
+}
+
+// RestoreToEtcd restores database contents from backup directory to etcd.
+func RestoreToEtcd(ctx context.Context, endpoint, dir string) error {
+	client, err := clientv3.New(clientv3.Config{Endpoints: []string{endpoint}})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	defer client.Close()
+
+	idx := 0
+	for {
+		b, err := os.ReadFile(keyFileName(dir, idx))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to read key file: %w", err)
+			}
+			logrus.WithField("entries", idx).Print("Completed database restore")
+			return nil
+		}
+		key := string(b)
+
+		value, err := os.ReadFile(dataFileName(dir, idx))
+		if err != nil {
+			return fmt.Errorf("failed to read value file: %w", err)
+		}
+
+		log := logrus.WithFields(logrus.Fields{"index": idx, "key": key})
+		log.Debug("Restore key")
+		if _, err := client.Put(ctx, key, string(value)); err != nil {
+			log.Error("Failed to restore key")
+		}
+
+		idx++
+	}
+}

--- a/pkg/migrator/util.go
+++ b/pkg/migrator/util.go
@@ -1,0 +1,27 @@
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s-dqlite/pkg/kine/client"
+)
+
+func putKey(ctx context.Context, c client.Client, key string, value []byte) error {
+	err := c.Create(ctx, key, value)
+	if err == nil {
+		return nil
+	} else if err.Error() != "key exists" {
+		return fmt.Errorf("failed to create key %q: %w", key, err)
+	}
+	// failed to create key because it exists, make a few attempts to overwrite it
+	for i := 0; i < 5 && err != nil; i++ {
+		time.Sleep(50 * time.Millisecond)
+		err = c.Put(ctx, key, value)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to put key %q: %w", key, err)
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

Replaces #53.

Build go-migrator as a sub-command of k8s-dqlite. Results in a reduced snap size and less binaries to build/bundle.