### PR TITLE
Added full disk watcher and startup condition

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var (
 
 		validateAvailableStorageInterval time.Duration
 		validateAvailableStorageMinBytes uint64
+		lowAvailableStorageAction        string
 	}
 
 	rootCmd = &cobra.Command{
@@ -70,6 +71,7 @@ var (
 				rootCmdOpts.minTLSVersion,
 				rootCmdOpts.validateAvailableStorageInterval,
 				rootCmdOpts.validateAvailableStorageMinBytes,
+				rootCmdOpts.lowAvailableStorageAction,
 			)
 			if err != nil {
 				logrus.WithError(err).Fatal("Failed to create server")
@@ -125,6 +127,7 @@ func init() {
 	rootCmd.Flags().StringVar(&rootCmdOpts.minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version for dqlite endpoint (tls10|tls11|tls12|tls13). Default is tls12")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.metrics, "metrics", true, "enable metrics endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
-	rootCmd.Flags().DurationVar(&rootCmdOpts.validateAvailableStorageInterval, "validate-storage-available-size-interval", 0, "Interval to check if the disk is running low on space. Set to 0 to disable the periodic disk size check")
-	rootCmd.Flags().Uint64Var(&rootCmdOpts.validateAvailableStorageMinBytes, "validate-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, the server will refuse to start")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.validateAvailableStorageInterval, "validate-storage-available-size-interval", 5*time.Second, "Interval to check if the disk is running low on space. Set to 0 to disable the periodic disk size check")
+	rootCmd.Flags().Uint64Var(&rootCmdOpts.validateAvailableStorageMinBytes, "validate-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, then the --low-available-storage-action is performed")
+	rootCmd.Flags().StringVar(&rootCmdOpts.lowAvailableStorageAction, "low-available-storage-action", "none", "Action to perform in case the available storage is low. One of (none|handover|terminate). none means no action is performed. handover means the dqlite node will handover its leadership role, if any. terminate means this dqlite node will shutdown")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,18 @@ var (
 			if rootCmdOpts.debug {
 				logrus.SetLevel(logrus.TraceLevel)
 			}
+			var stat unix.Statfs_t
+
+			unix.Statfs(rootCmdOpts.dir, &stat)
+
+			avail := stat.Bavail * uint64(stat.Bsize)
+
+			var disk_threshold uint64 = 10000000
+
+			// If available space is less than 10MB reject to start.
+			if avail < disk_threshold {
+				logrus.WithField("dir", rootCmdOpts.dir).Fatal("Disk is critically low, rejecting startup")
+			}
 
 			if rootCmdOpts.profiling {
 				go func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,9 +30,9 @@ var (
 		metrics                bool
 		metricsAddress         string
 
-		validateAvailableStorageInterval time.Duration
-		validateAvailableStorageMinBytes uint64
-		lowAvailableStorageAction        string
+		watchAvailableStorageInterval time.Duration
+		watchAvailableStorageMinBytes uint64
+		lowAvailableStorageAction     string
 	}
 
 	rootCmd = &cobra.Command{
@@ -69,8 +69,8 @@ var (
 				rootCmdOpts.diskMode,
 				rootCmdOpts.clientSessionCacheSize,
 				rootCmdOpts.minTLSVersion,
-				rootCmdOpts.validateAvailableStorageInterval,
-				rootCmdOpts.validateAvailableStorageMinBytes,
+				rootCmdOpts.watchAvailableStorageInterval,
+				rootCmdOpts.watchAvailableStorageMinBytes,
 				rootCmdOpts.lowAvailableStorageAction,
 			)
 			if err != nil {
@@ -127,7 +127,7 @@ func init() {
 	rootCmd.Flags().StringVar(&rootCmdOpts.minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version for dqlite endpoint (tls10|tls11|tls12|tls13). Default is tls12")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.metrics, "metrics", true, "enable metrics endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
-	rootCmd.Flags().DurationVar(&rootCmdOpts.validateAvailableStorageInterval, "validate-storage-available-size-interval", 5*time.Second, "Interval to check if the disk is running low on space. Set to 0 to disable the periodic disk size check")
-	rootCmd.Flags().Uint64Var(&rootCmdOpts.validateAvailableStorageMinBytes, "validate-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, then the --low-available-storage-action is performed")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.watchAvailableStorageInterval, "watch-storage-available-size-interval", 5*time.Second, "Interval to check if the disk is running low on space. Set to 0 to disable the periodic disk size check")
+	rootCmd.Flags().Uint64Var(&rootCmdOpts.watchAvailableStorageMinBytes, "watch-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, then the --low-available-storage-action is performed")
 	rootCmd.Flags().StringVar(&rootCmdOpts.lowAvailableStorageAction, "low-available-storage-action", "none", "Action to perform in case the available storage is low. One of (none|handover|terminate). none means no action is performed. handover means the dqlite node will handover its leadership role, if any. terminate means this dqlite node will shutdown")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var (
 			if err != nil {
 				logrus.WithError(err).Fatal("failed to check storage capacity")
 			} else if isFull {
-				logrus.WithField("dir", rootCmdOpts.dir).Fatal("Disk is critically low, rejecting startup")
+				logrus.WithField("dir", rootCmdOpts.dir).Fatal("Disk is critically low, refusing to start")
 			}
 
 			if rootCmdOpts.profiling {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -337,5 +337,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if err := s.app.Close(); err != nil {
 		return fmt.Errorf("failed to close dqlite app: %w", err)
 	}
+	close(s.mustStopCh)
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -53,7 +53,7 @@ var expectedFilesDuringInitialization = map[string]struct{}{
 }
 
 // New creates a new instance of Server based on configuration.
-func New(dir string, listen string, enableTLS bool, diskMode bool, clientSessionCacheSize uint, minTLSVersion string, validateAvailableStorageInterval time.Duration, watchAvailableStorageMinBytes uint64, lowAvailableStorageAction string) (*Server, error) {
+func New(dir string, listen string, enableTLS bool, diskMode bool, clientSessionCacheSize uint, minTLSVersion string, watchAvailableStorageInterval time.Duration, watchAvailableStorageMinBytes uint64, lowAvailableStorageAction string) (*Server, error) {
 	var (
 		options         []app.Option
 		kineConfig      endpoint.Config
@@ -263,7 +263,7 @@ func New(dir string, listen string, enableTLS bool, diskMode bool, clientSession
 
 		storageDir:                    dir,
 		watchAvailableStorageMinBytes: watchAvailableStorageMinBytes,
-		watchAvailableStorageInterval: validateAvailableStorageInterval,
+		watchAvailableStorageInterval: watchAvailableStorageInterval,
 		actionOnLowDisk:               lowAvailableStorageAction,
 
 		mustStopCh: make(chan struct{}, 1),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -284,7 +284,7 @@ func (s *Server) watchAvailableStorageSize(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(s.validateStorageAvailableInterval):
-			if err := validateStorageDirAvailableSize(s.storageDir, s.validateAvailableStorageMinBytes); err != nil {
+			if err := checkAvailableStorageSize(s.storageDir, s.validateAvailableStorageMinBytes); err != nil {
 				err := fmt.Errorf("periodic check for available disk storage failed: %w", err)
 
 				switch s.actionOnLowDisk {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,6 +22,7 @@ import (
 type Server struct {
 	// app is the dqlite application driving the server.
 	app *app.App
+
 	// kineConfig is the configuration to use for starting kine against the dqlite application.
 	kineConfig endpoint.Config
 
@@ -281,7 +282,7 @@ func (s *Server) watchStorage(ctx context.Context) {
 	}
 }
 
-// Terminated returns a channel that can be used to check whether the server must stop.
+// MustStop returns a channel that can be used to check whether the server must stop.
 func (s *Server) MustStop() <-chan struct{} {
 	return s.mustStopCh
 }

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v2"
 )
 
@@ -38,4 +39,15 @@ func fileExists(path ...string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+func IsStorageFull(storageDir string, diskThreshold uint64) (bool, error) {
+	var stat unix.Statfs_t
+	err := unix.Statfs(storageDir, &stat)
+	if err != nil {
+		return false, fmt.Errorf("failed to check disk capacity: %w", err)
+	}
+	avail := stat.Bavail * uint64(stat.Bsize)
+	// If available space is less than 10MB reject to start.
+	return avail < diskThreshold, nil
 }

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -41,7 +41,7 @@ func fileExists(path ...string) (bool, error) {
 	return true, nil
 }
 
-func validateStorageDirAvailableSize(storageDir string, minimumBytes uint64) error {
+func checkAvailableStorageSize(storageDir string, minimumBytes uint64) error {
 	var stat unix.Statfs_t
 	if err := unix.Statfs(storageDir, &stat); err != nil {
 		return fmt.Errorf("failed to check available disk size: %w", err)


### PR DESCRIPTION
This would be a starting point to handle full disk cases. The conditions can checked by a watcher which will try to gracefully handover leadership/voter rights and shutdown. The syscall for `unix.Statfs` is really fast, so this check can be handled on queries that would put data to the disk such as `CREATE`,`UPDATE` and `DELETE`.  If having a watcher seems to be the better idea, this work can be finalized by cleaning up some of the ugly code.