### PR TITLE
Add admission control

### DIFF
--- a/pkg/kine/drivers/generic/admission.go
+++ b/pkg/kine/drivers/generic/admission.go
@@ -1,0 +1,48 @@
+package generic
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// AdmissionControlPolicy interface defines the admission policy contract.
+type AdmissionControlPolicy interface {
+	// Admit checks whether the query should be admitted.
+	// If the query is not admitted, a non-nil error is returned with the reason why the query was denied.
+	// If the query is admitted, then the error will be nil and a callback function is returned to the caller.
+	// The caller must execute it after finishing the query
+	Admit(context.Context) (callOnFinish func(), err error)
+}
+
+// allowAllPolicy always admits queries.
+type allowAllPolicy struct{}
+
+// Admit always admits requests for AllowAllPolicy.
+func (p *allowAllPolicy) Admit(context.Context) (func(), error) {
+	return func() {}, nil
+}
+
+// limitPolicy denies queries when the maximum threshold is reached.
+type limitPolicy struct {
+	MaxRunningTxn int64
+	semaphore     *semaphore.Weighted
+}
+
+func newLimitPolicy(maxRunningTxn int64) *limitPolicy {
+	return &limitPolicy{
+		MaxRunningTxn: maxRunningTxn,
+		semaphore:     semaphore.NewWeighted(maxRunningTxn),
+	}
+}
+
+func (p *limitPolicy) admit(ctx context.Context) (func(), error) {
+	ok := p.semaphore.TryAcquire(1)
+	if !ok {
+		return func() {}, fmt.Errorf("current Txns reached limit (%d)", p.MaxRunningTxn)
+	}
+	return func() {
+		p.semaphore.Release(1)
+	}, nil
+}

--- a/pkg/kine/drivers/generic/admission_test.go
+++ b/pkg/kine/drivers/generic/admission_test.go
@@ -1,0 +1,43 @@
+package generic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestAllowAllPolicy_Admit(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	policy := &allowAllPolicy{}
+
+	callOnFinish, err := policy.Admit(context.Background())
+
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(callOnFinish).ToNot(gomega.BeNil())
+}
+
+func TestLimitPolicy_Admit(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	policy := newLimitPolicy(2)
+
+	// First two should succeed
+	done1, err := policy.admit(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(done1).ToNot(gomega.BeNil())
+	done2, err := policy.admit(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(done2).ToNot(gomega.BeNil())
+
+	// Third should be denied
+	done3, err := policy.admit(context.Background())
+	g.Expect(err).To(gomega.HaveOccurred())
+	// should still return a valid function as callers otherwise might segfault if they not check for nil.
+	g.Expect(done3).ToNot(gomega.BeNil())
+
+	// Complete a call - now the next query should be admitted again.
+	done1()
+	_, err = policy.admit(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(done3).ToNot(gomega.BeNil())
+}

--- a/test/mixed_workload_test.go
+++ b/test/mixed_workload_test.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// BenchmarkGet is a benchmark for the Get operation.
+func TestMixed(t *testing.T) {
+	ctx := context.Background()
+	client, _ := newKine(ctx, t)
+	g := NewWithT(t)
+
+	// create a key space of 1000 items
+	{
+		for i := 0; i < 1000; i++ {
+			key := fmt.Sprintf("Key-%d", i)
+			value := fmt.Sprintf("Value-%d", i)
+			resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+				Then(clientv3.OpPut(key, value)).
+				Commit()
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Succeeded).To(BeTrue())
+		}
+	}
+
+	t.Run("LatestRevision", func(t *testing.T) {
+		g := NewWithT(t)
+		var wg sync.WaitGroup
+
+		reader := func(first int, last int) {
+			defer wg.Done()
+			for i := first; i < last; i++ {
+				key := fmt.Sprintf("Key-%d", i)
+				resp, err := client.Get(ctx, key, clientv3.WithRange(""))
+				g.Expect(err).To(BeNil())
+				g.Expect(resp.Kvs).To(HaveLen(1))
+			}
+		}
+
+		writer := func(first int, last int) {
+			defer wg.Done()
+			for i := first; i < last; i++ {
+				key := fmt.Sprintf("Key-%d", i)
+				new_value := fmt.Sprintf("New-Value-%d", i)
+				for {
+					resp, err := client.Get(ctx, key, clientv3.WithRange(""))
+					if err != nil {
+						t.Logf("Could not get %s\n", key)
+						continue
+					}
+					lastModRev := resp.Kvs[0].ModRevision
+					put_resp, err := client.Txn(ctx).
+						If(clientv3.Compare(clientv3.ModRevision(key), "=", lastModRev)).
+						Then(clientv3.OpPut(key, new_value)).
+						Else(clientv3.OpGet(key, clientv3.WithRange(""))).
+						Commit()
+
+					if err == nil && put_resp.Succeeded == true {
+						break
+					}
+				}
+			}
+		}
+
+		readers := 50
+		readers_replication := 3
+		read_entries := 1000 / readers
+		writers := 500
+		writers_replication := 10
+		write_entries := 1000 / writers
+		wg.Add(readers*readers_replication + writers*writers_replication)
+
+		start := time.Now()
+		for i := 0; i < readers; i++ {
+			for j := 0; j < readers_replication; j++ {
+				go reader(i*read_entries, (i+1)*read_entries)
+			}
+		}
+		for i := 0; i < writers; i++ {
+			for j := 0; j < writers_replication; j++ {
+				go writer(i*write_entries, (i+1)*write_entries)
+			}
+		}
+
+		wg.Wait()
+		duration := time.Since(start)
+
+		t.Logf("Executed 1000 queries in %.2f seconds\n", duration.Seconds())
+	})
+}


### PR DESCRIPTION
This PR adds a way to fail requests early based on admission policies which reduces the load on the database.
The following policies are currently available:
    
* `allow-all`: Disables admission control
* `limit`: Denies queries if maximum amount of Txn is reached.

Closes MK-1302