### PR TITLE
Add `--admission-control-only-write-queries` flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ var (
 
 		admissionControlPolicy   string
 		acpLimitMaxConcurrentTxn int64
+		acpOnlyWriteQueries      bool
 	}
 
 	rootCmd = &cobra.Command{
@@ -77,6 +78,7 @@ var (
 				rootCmdOpts.lowAvailableStorageAction,
 				rootCmdOpts.admissionControlPolicy,
 				rootCmdOpts.acpLimitMaxConcurrentTxn,
+				rootCmdOpts.acpOnlyWriteQueries,
 			)
 			if err != nil {
 				logrus.WithError(err).Fatal("Failed to create server")
@@ -138,4 +140,5 @@ func init() {
 	rootCmd.Flags().StringVar(&rootCmdOpts.admissionControlPolicy, "admission-control-policy", "allow-all", "Transaction admission control policy to use. One of (allow-all|limit-concurrent-transactions). Set to allow-all to disable the admission control")
 	// TODO(MK-1408): This value is highly dependend on underlying hardware, thus making the default value a bit useless. The linked card will implement a dynamic way to set this value.
 	rootCmd.Flags().Int64Var(&rootCmdOpts.acpLimitMaxConcurrentTxn, "admission-control-policy-limit-max-concurrent-transactions", 300, "Maximum number of transactions that are allowed to run concurrently. Transactions will not be admitted after the limit is reached.")
+	rootCmd.Flags().BoolVar(&rootCmdOpts.acpOnlyWriteQueries, "admission-control-only-for-write-queries", false, "If set, admission control will only be applied to write queries.")
 }

--- a/pkg/kine/drivers/generic/admission.go
+++ b/pkg/kine/drivers/generic/admission.go
@@ -18,16 +18,27 @@ type AdmissionControlPolicy interface {
 }
 
 const (
-	statusAccepted string = "accepted"
-	statusDenied   string = "denied"
+	// operation was evaluated by the admission control and accepted
+	resultAccepted string = "accepted"
+	// operation was evaluated by the admission control and denied by policy
+	resultDenied string = "denied"
 )
+
+// Queries that perform write operations on the database
+var writeQueries = map[string]struct{}{
+	"update_compact_sql":        {},
+	"delete_sql":                {},
+	"fill_sql":                  {},
+	"insert_last_insert_id_sql": {},
+	"insert_sql":                {},
+}
 
 // allowAllPolicy always admits queries.
 type allowAllPolicy struct{}
 
 // Admit always admits requests for AllowAllPolicy.
 func (p *allowAllPolicy) Admit(ctx context.Context, txName string) (func(), error) {
-	recordOpAdmissionControl(txName, statusAccepted)
+	recordOpAdmissionControl(txName, resultAccepted)
 	incCurrentOps(txName)
 	return func() {
 		decCurrentOps(txName)
@@ -38,33 +49,46 @@ func (p *allowAllPolicy) Admit(ctx context.Context, txName string) (func(), erro
 type limitPolicy struct {
 	maxConcurrentTxn int64
 	semaphore        *semaphore.Weighted
+	onlyWriteQueries bool
 }
 
-func newLimitPolicy(maxConcurrentTxn int64) *limitPolicy {
+func newLimitPolicy(onlyWriteQueries bool, maxConcurrentTxn int64) *limitPolicy {
 	return &limitPolicy{
 		maxConcurrentTxn: maxConcurrentTxn,
 		semaphore:        semaphore.NewWeighted(maxConcurrentTxn),
+		onlyWriteQueries: onlyWriteQueries,
 	}
+
+}
+
+func (p *limitPolicy) shouldCheck(txName string) bool {
+	_, isWriteQuery := writeQueries[txName]
+	return !p.onlyWriteQueries || isWriteQuery
 }
 
 func (p *limitPolicy) Admit(ctx context.Context, txName string) (func(), error) {
-	ok := p.semaphore.TryAcquire(1)
-	if !ok {
-		recordOpAdmissionControl(txName, statusDenied)
-		return func() {}, fmt.Errorf("number of concurrent database operations reached limit (%d)", p.maxConcurrentTxn)
+	if p.shouldCheck(txName) {
+		ok := p.semaphore.TryAcquire(1)
+		if !ok {
+			recordOpAdmissionControl(txName, resultDenied)
+			return func() {}, fmt.Errorf("number of concurrent database operations reached limit (%d)", p.maxConcurrentTxn)
+		}
 	}
-	recordOpAdmissionControl(txName, statusAccepted)
+
+	recordOpAdmissionControl(txName, resultAccepted)
 	incCurrentOps(txName)
 	return func() {
 		decCurrentOps(txName)
-		p.semaphore.Release(1)
+		if p.shouldCheck(txName) {
+			p.semaphore.Release(1)
+		}
 	}, nil
 }
 
-func NewAdmissionControlPolicy(policyName string, limitMaxConcurrentTxn int64) AdmissionControlPolicy {
+func NewAdmissionControlPolicy(policyName string, onlyWriteQueries bool, limitMaxConcurrentTxn int64) AdmissionControlPolicy {
 	switch policyName {
 	case "limit":
-		return newLimitPolicy(limitMaxConcurrentTxn)
+		return newLimitPolicy(onlyWriteQueries, limitMaxConcurrentTxn)
 	case "allow-all":
 		return &allowAllPolicy{}
 

--- a/pkg/kine/drivers/generic/admission_test.go
+++ b/pkg/kine/drivers/generic/admission_test.go
@@ -11,7 +11,7 @@ func TestAllowAllPolicy_Admit(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	policy := &allowAllPolicy{}
 
-	callOnFinish, err := policy.Admit(context.Background(), "tx")
+	callOnFinish, err := policy.Admit(context.Background(), "get_size_sql")
 
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(callOnFinish).ToNot(gomega.BeNil())
@@ -19,25 +19,52 @@ func TestAllowAllPolicy_Admit(t *testing.T) {
 
 func TestLimitPolicy_Admit(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	policy := newLimitPolicy(2)
+	policy := newLimitPolicy(false, 2)
 
 	// First two should succeed
-	done1, err := policy.Admit(context.Background(), "tx")
+	done1, err := policy.Admit(context.Background(), "get_size_sql")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(done1).ToNot(gomega.BeNil())
-	done2, err := policy.Admit(context.Background(), "tx")
+	done2, err := policy.Admit(context.Background(), "get_size_sql")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(done2).ToNot(gomega.BeNil())
 
 	// Third should be denied
-	done3, err := policy.Admit(context.Background(), "tx")
+	done3, err := policy.Admit(context.Background(), "get_size_sql")
 	g.Expect(err).To(gomega.HaveOccurred())
 	// should still return a valid function as callers otherwise might segfault if they not check for nil.
 	g.Expect(done3).ToNot(gomega.BeNil())
 
 	// Complete a call - now the next query should be admitted again.
 	done1()
-	_, err = policy.Admit(context.Background(), "tx")
+	_, err = policy.Admit(context.Background(), "get_size_sql")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(done3).ToNot(gomega.BeNil())
+}
+
+func TestLimitPolicy_Admit_OnlyCheckWriteQueries(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	policy := newLimitPolicy(true, 2)
+
+	// Read queries should always succeed
+	_, err := policy.Admit(context.Background(), "get_size_sql")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = policy.Admit(context.Background(), "get_size_sql")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = policy.Admit(context.Background(), "get_size_sql")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// write queries should be evaluated, thus fail after second call
+	done1, err := policy.Admit(context.Background(), "insert_sql")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = policy.Admit(context.Background(), "delete_sql")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = policy.Admit(context.Background(), "fill_sql")
+	g.Expect(err).To(gomega.HaveOccurred())
+
+	// Another write query should be possible after one is done
+	done1()
+	_, err = policy.Admit(context.Background(), "fill_sql")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
 }

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -28,6 +28,7 @@ type opts struct {
 
 	admissionControlPolicy                      string
 	admissionControlPolicyLimitMaxConcurrentTxn int64
+	admissionControlOnlyWriteQueries            bool
 }
 
 func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
@@ -98,6 +99,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 	dialect.PollInterval = opts.pollInterval
 	dialect.AdmissionControlPolicy = generic.NewAdmissionControlPolicy(
 		opts.admissionControlPolicy,
+		opts.admissionControlOnlyWriteQueries,
 		opts.admissionControlPolicyLimitMaxConcurrentTxn,
 	)
 
@@ -208,6 +210,12 @@ func parseOpts(dsn string) (opts, error) {
 				return opts{}, fmt.Errorf("failed to parse max-concurrent-txn value %q: %w", vs[0], err)
 			}
 			result.admissionControlPolicyLimitMaxConcurrentTxn = d
+		case "admission-control-only-write-queries":
+			d, err := strconv.ParseBool(vs[0])
+			if err != nil {
+				return opts{}, fmt.Errorf("failed to parse admission-control-only-writes value %q: %w", vs[0], err)
+			}
+			result.admissionControlOnlyWriteQueries = d
 		default:
 			return opts{}, fmt.Errorf("unknown option %s=%v", k, vs)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -53,7 +53,20 @@ var expectedFilesDuringInitialization = map[string]struct{}{
 }
 
 // New creates a new instance of Server based on configuration.
-func New(dir string, listen string, enableTLS bool, diskMode bool, clientSessionCacheSize uint, minTLSVersion string, watchAvailableStorageInterval time.Duration, watchAvailableStorageMinBytes uint64, lowAvailableStorageAction string, admissionControlPolicy string, admissionControlPolicyLimitMaxConcurrentTxn int64) (*Server, error) {
+func New(
+	dir string,
+	listen string,
+	enableTLS bool,
+	diskMode bool,
+	clientSessionCacheSize uint,
+	minTLSVersion string,
+	watchAvailableStorageInterval time.Duration,
+	watchAvailableStorageMinBytes uint64,
+	lowAvailableStorageAction string,
+	admissionControlPolicy string,
+	admissionControlPolicyLimitMaxConcurrentTxn int64,
+	admissionControlOnlyWriteQueries bool,
+) (*Server, error) {
 	var (
 		options         []app.Option
 		kineConfig      endpoint.Config
@@ -256,6 +269,7 @@ func New(dir string, listen string, enableTLS bool, diskMode bool, clientSession
 
 	params["admission-control-policy"] = []string{admissionControlPolicy}
 	params["admission-control-policy-limit-max-concurrent-txn"] = []string{fmt.Sprintf("%v", admissionControlPolicyLimitMaxConcurrentTxn)}
+	params["admission-control-only-write-queries"] = []string{fmt.Sprintf("%v", admissionControlOnlyWriteQueries)}
 
 	kineConfig.Listener = listen
 	kineConfig.Endpoint = fmt.Sprintf("dqlite://k8s?%s", params.Encode())


### PR DESCRIPTION
If this flag is enabled, the admission control will only perform checks on write queries. Read queries will be ignored.