### PR TITLE
Fix wrong parameter for sqlite

### DIFF
--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -64,7 +64,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		dataSourceName = "./db/state.db?_journal=WAL&cache=shared"
 	}
 
-	dialect, err := generic.Open(ctx, driverName, dataSourceName, "?", false)
+	dialect, err := generic.Open(ctx, driverName, opts.dsn, "?", false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
In #69 the options parsing was moved from dqlite.go to sqlite.go. However, the dataSourceName with the query parameters was wrongly passed to the `generic.Open` call instead of the parsed `opts.dsn` that removed the query parameters.

