### PR TITLE
Rewritten list query, test and fix [#82]

### DIFF
--- a/test/update_test.go
+++ b/test/update_test.go
@@ -157,16 +157,6 @@ func addSameEntries(ctx context.Context, g Gomega, client *clientv3.Client, numE
 	}
 }
 
-func addEntry(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
-	resp, err := client.Txn(ctx).
-		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-		Then(clientv3.OpPut(key, value)).
-		Commit()
-
-	g.Expect(err).To(BeNil())
-	g.Expect(resp.Succeeded).To(BeTrue())
-}
-
 func updateEntry(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
 
 	resp, err := client.Get(ctx, key, clientv3.WithRange(""))

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -77,6 +78,24 @@ func TestUpdate(t *testing.T) {
 			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
 		}
 	})
+	t.Run("UpdateSameKeyLinerity", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Add a large number of entries, two times and
+		// it should take approximately same amout of time
+		numAddEntries := 1000
+
+		startFirst := time.Now()
+		addSameEntries(ctx, g, client, numAddEntries, true)
+		durationFirstBatch := time.Since(startFirst)
+
+		startSecond := time.Now()
+		addSameEntries(ctx, g, client, numAddEntries, false)
+		durationSecondBatch := time.Since(startSecond)
+
+		g.Expect(durationSecondBatch <= durationFirstBatch*2).To(BeTrue())
+
+	})
 
 	// Trying to update an old revision(in compare) should fail
 	t.Run("UpdateOldRevisionFails", func(t *testing.T) {
@@ -122,6 +141,47 @@ func TestUpdate(t *testing.T) {
 		}
 
 	})
+
+}
+
+func addSameEntries(ctx context.Context, g Gomega, client *clientv3.Client, numEntries int, create_first bool) {
+	for i := 0; i < numEntries; i++ {
+		key := "testkey-same"
+		value := fmt.Sprintf("value-%d", i)
+
+		if i != 0 || !create_first {
+			updateEntry(ctx, g, client, key, value)
+		} else {
+			addEntry(ctx, g, client, key, value)
+		}
+	}
+}
+
+func addEntry(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
+	resp, err := client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+		Then(clientv3.OpPut(key, value)).
+		Commit()
+
+	g.Expect(err).To(BeNil())
+	g.Expect(resp.Succeeded).To(BeTrue())
+}
+
+func updateEntry(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
+
+	resp, err := client.Get(ctx, key, clientv3.WithRange(""))
+
+	g.Expect(err).To(BeNil())
+	g.Expect(resp.Kvs).To(HaveLen(1))
+
+	resp2, err2 := client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", resp.Kvs[0].ModRevision)).
+		Then(clientv3.OpPut(key, value)).
+		Else(clientv3.OpGet(key, clientv3.WithRange(""))).
+		Commit()
+
+	g.Expect(err2).To(BeNil())
+	g.Expect(resp2.Succeeded).To(BeTrue())
 
 }
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -78,7 +78,7 @@ func TestUpdate(t *testing.T) {
 			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
 		}
 	})
-	t.Run("UpdateSameKeyLinerity", func(t *testing.T) {
+	t.Run("UpdateSameKeyLinearity", func(t *testing.T) {
 		g := NewWithT(t)
 
 		// Add a large number of entries, two times and


### PR DESCRIPTION
Solves [https://github.com/canonical/k8s-dqlite/issues/82](https://github.com/canonical/k8s-dqlite/issues/82)

Adds test to expose slowness of list query (https://github.com/canonical/k8s-dqlite/issues/82)
Original list query had maybe quadratic complexity [(plot)](https://www.wolframalpha.com/input?i=quadratic+fit+calculator&assumption=%7B%22F%22%2C+%22QuadraticFitCalculator%22%2C+%22data%22%7D+-%3E%22%7B2551219%2C4238600%2C6427871%2C9495735%2C14600343%2C18155273%2C24599527%2C29835900%2C38340280%2C48312167%2C56213177%2C67317845%2C69894101%2C88913819%2C102723989%2C142948612%2C124230579%2C143282009%2C169605043%7D%22) in terms of number of rows with same name.
New query passes the test, it  still has [superlinear](https://www.wolframalpha.com/input?i=linear+fit+calculator&assumption=%7B%22F%22%2C+%22LinearFitCalculator%22%2C+%22data%22%7D+-%3E%22%7B1948369%2C2440967%2C2547249%2C2096332%2C2208657%2C2143011%2C2219463%2C3453706%2C2177383%2C2983581%2C2320405%2C4230266%2C2220269%2C2279836%2C2210087%2C2294555%2C2515762%2C2526467%2C2786873%2C2557740%2C2663338%2C2712177%2C2600923%2C2615612%7D%22) complexity. But it has to be taken with grain of salt as I meassured individual updates.

Test performs two subsequents batches of 1000 updates.

Orignal query
- duration of first batch: 18 320 405 224ns
- duration of subsequent batch: 105 316 382 474ns

New Query
- duration of first batch:  2 372 000 975ns
- duration of subsequent batch duration: 2 684 759 515ns

Future work: By having specialized query for getting single name,(no prefix or range), we can have even faster, constant time complexity of list. 

