### PR TITLE
Follow up fixes on k8s-dqlite build process

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -138,7 +138,7 @@ jobs:
       - name: Build shared binaries
         run: |
           make -j dynamic
-          export LD_LIBRARY_PATH=bin/dynamic
+          export LD_LIBRARY_PATH=bin/dynamic/lib
 
           ./bin/dynamic/k8s-dqlite --help
           ./bin/dynamic/k8s-dqlite migrator --help

--- a/hack/dynamic-go-install.sh
+++ b/hack/dynamic-go-install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xeu
+
+DIR="$(realpath `dirname "${0}"`)"
+
+. "${DIR}/dynamic-dqlite.sh"
+
+go install \
+  -tags dqlite,libsqlite3 \
+  -ldflags '-s -w' \
+  "${@}"

--- a/hack/static-go-install.sh
+++ b/hack/static-go-install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xeu
+
+DIR="$(realpath `dirname "${0}"`)"
+
+. "${DIR}/static-dqlite.sh"
+
+go install \
+  -tags dqlite,libsqlite3 \
+  -ldflags '-s -w -linkmode "external" -extldflags "-static"' \
+  "${@}"


### PR DESCRIPTION
## Summary

Follow up fixes on #90 

## Changes

- use bin/dynamic/lib for dqlite shared libraries
- configurable build-scripts directory
- use `go install` for dqlite cli tool
