### PR TITLE
Use rpath for dynamically linked binaries

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -138,7 +138,6 @@ jobs:
       - name: Build shared binaries
         run: |
           make -j dynamic
-          export LD_LIBRARY_PATH=bin/dynamic/lib
 
           ./bin/dynamic/k8s-dqlite --help
           ./bin/dynamic/k8s-dqlite migrator --help

--- a/hack/dynamic-go-build.sh
+++ b/hack/dynamic-go-build.sh
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go build \
   -tags dqlite,libsqlite3 \
-  -ldflags '-s -w' \
+  -ldflags '-s -w -extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"

--- a/hack/dynamic-go-install.sh
+++ b/hack/dynamic-go-install.sh
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go install \
   -tags dqlite,libsqlite3 \
-  -ldflags '-s -w' \
+  -ldflags '-s -w -extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"


### PR DESCRIPTION
### Summary

Update build scripts for dynamically linked binaries to look for dqlite in `$PWD/lib` and `$PWD/../lib` by default.
