### PR TITLE
Bench time workload

### DIFF
--- a/test/create_test.go
+++ b/test/create_test.go
@@ -39,19 +39,25 @@ func TestCreate(t *testing.T) {
 
 // BenchmarkCreate is a benchmark for the Create operation.
 func BenchmarkCreate(b *testing.B) {
+	b.StopTimer()
 	ctx := context.Background()
 	client, _ := newKine(ctx, b)
 
+	b.StartTimer()
 	g := NewWithT(b)
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
-		resp, err := client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-			Then(clientv3.OpPut(key, value)).
-			Commit()
-
-		g.Expect(err).To(BeNil())
-		g.Expect(resp.Succeeded).To(BeTrue())
+		createKey(ctx, g, client, key, value)
 	}
+}
+
+func createKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
+	resp, err := client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+		Then(clientv3.OpPut(key, value)).
+		Commit()
+
+	g.Expect(err).To(BeNil())
+	g.Expect(resp.Succeeded).To(BeTrue())
 }

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -48,6 +48,7 @@ func TestDelete(t *testing.T) {
 
 // BenchmarkDelete is a benchmark for the delete operation.
 func BenchmarkDelete(b *testing.B) {
+	b.StopTimer()
 	ctx := context.Background()
 	client, _ := newKine(ctx, b)
 
@@ -58,6 +59,7 @@ func BenchmarkDelete(b *testing.B) {
 		createKey(ctx, g, client, key, value)
 	}
 
+	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		deleteKey(ctx, g, client, key)
@@ -88,14 +90,4 @@ func assertKey(ctx context.Context, g Gomega, client *clientv3.Client, key strin
 	g.Expect(resp.Kvs).To(HaveLen(1))
 	g.Expect(resp.Kvs[0].Key).To(Equal([]byte(key)))
 	g.Expect(resp.Kvs[0].Value).To(Equal([]byte(value)))
-}
-
-func createKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
-	resp, err := client.Txn(ctx).
-		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-		Then(clientv3.OpPut(key, value)).
-		Commit()
-
-	g.Expect(err).To(BeNil())
-	g.Expect(resp.Succeeded).To(BeTrue())
 }

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -169,26 +169,18 @@ func TestGet(t *testing.T) {
 
 // BenchmarkGet is a benchmark for the Get operation.
 func BenchmarkGet(b *testing.B) {
+	b.StartTimer()
 	ctx := context.Background()
 	client, _ := newKine(ctx, b)
 	g := NewWithT(b)
 
 	// create a kv
-	{
-		resp, err := client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-			Then(clientv3.OpPut("testKey", "testValue")).
-			Commit()
-		g.Expect(err).To(BeNil())
-		g.Expect(resp.Succeeded).To(BeTrue())
-	}
+	createKey(ctx, g, client, "testKey", "testValue")
 
-	b.Run("LatestRevision", func(b *testing.B) {
-		g := NewWithT(b)
-		for i := 0; i < b.N; i++ {
-			resp, err := client.Get(ctx, "testKey", clientv3.WithRange(""))
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(1))
-		}
-	})
+	b.StopTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := client.Get(ctx, "testKey", clientv3.WithRange(""))
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(1))
+	}
 }

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -72,10 +72,12 @@ func TestLease(t *testing.T) {
 
 // BenchmarkLease is a benchmark for the lease operation.
 func BenchmarkLease(b *testing.B) {
+	b.StopTimer()
 	ctx := context.Background()
 	client, _ := newKine(ctx, b)
 
 	g := NewWithT(b)
+	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		var ttl int64 = int64(i + 1)
 		resp, err := client.Lease.Grant(ctx, ttl)


### PR DESCRIPTION
This PR aims at measuring time only for the workload of the benchmarks and ignore the setup work. This way we should get more accurate results to compare.