### PR TITLE
Allow builds without libdqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,16 @@ go.vet:
 	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-vet.sh ./...
 
 go.test:
-	go test -tags=libsqlite3 -v ./test
+	go test -v -p 1 ./...
 
 go.test.dqlite:
-	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v ./test
+	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v ./...
 
 go.bench:
-	go test -tags=libsqlite3 -v ./test -run "^$$" -bench "Benchmark" -benchmem
+	go test -tags=libsqlite3 -v ./... -run "^$$" -bench "Benchmark" -benchmem
 
 go.bench.dqlite:
-	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v ./test -run "^$$" -bench "Benchmark" -benchmem
+	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v ./... -run "^$$" -bench "Benchmark" -benchmem
 
 ## Static Builds
 static: bin/static/k8s-dqlite bin/static/dqlite

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,4 +155,9 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootCmdOpts.etcdMode, "etcd-mode", false, "Run in etcd mode")
 
 	rootCmd.AddCommand(dbctl.Command)
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:  "version",
+		RunE: func(cmd *cobra.Command, args []string) error { return printVersions() },
+	})
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,10 +1,10 @@
+//go:build dqlite
+
 package cmd
 
 import (
 	"fmt"
 	"runtime"
-
-	"github.com/spf13/cobra"
 )
 
 /*
@@ -48,18 +48,8 @@ void print_dqlite_library_versions() {
 */
 import "C"
 
-var (
-	versionCmd = &cobra.Command{
-		Use: "version",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("go:", runtime.Version())
-			C.print_dqlite_library_versions()
-
-			return nil
-		},
-	}
-)
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
+func printVersions() error {
+	fmt.Println("go:", runtime.Version())
+	C.print_dqlite_library_versions()
+	return nil
 }

--- a/cmd/version_no_dqlite.go
+++ b/cmd/version_no_dqlite.go
@@ -1,0 +1,9 @@
+//go:build !dqlite
+
+package cmd
+
+import "fmt"
+
+func printVersions() error {
+	return fmt.Errorf("dqlite is not supported, compile with \"-tags dqlite\"")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,3 +1,5 @@
+//go:build dqlite
+
 package server
 
 import (

--- a/pkg/server/server_no_dqlite.go
+++ b/pkg/server/server_no_dqlite.go
@@ -1,0 +1,39 @@
+//go:build !dqlite
+
+package server
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var errNoDqlite = errors.New("dqlite is not supported, compile with \"-tags dqlite\"")
+var closedCh = make(chan struct{})
+
+func init() {
+	close(closedCh)
+}
+
+type Server struct{}
+
+func (*Server) Start(ctx context.Context) error    { return errNoDqlite }
+func (*Server) MustStop() <-chan struct{}          { return closedCh }
+func (*Server) Shutdown(ctx context.Context) error { return errNoDqlite }
+
+func New(
+	dir string,
+	listen string,
+	enableTLS bool,
+	diskMode bool,
+	clientSessionCacheSize uint,
+	minTLSVersion string,
+	watchAvailableStorageInterval time.Duration,
+	watchAvailableStorageMinBytes uint64,
+	lowAvailableStorageAction string,
+	admissionControlPolicy string,
+	admissionControlPolicyLimitMaxConcurrentTxn int64,
+	admissionControlOnlyWriteQueries bool,
+) (*Server, error) {
+	return nil, errNoDqlite
+}


### PR DESCRIPTION
This PR aims at making it possible to `go build .` the project without libdqlite in the system. This is essential if we want to be able to test all project (i.e. run `go test ./...`).