### PR TITLE
Add synchronization primitive for server shutdown

### DIFF
--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -306,6 +306,23 @@ func (d *Generic) Prepare() error {
 	return nil
 }
 
+func (d *Generic) Close() {
+	d.getRevisionSQLPrepared.Close()
+	d.countCurrentSQLPrepared.Close()
+	d.countRevisionSQLPrepared.Close()
+	d.afterSQLPrefixPrepared.Close()
+	d.deleteSQLPrepared.Close()
+	d.updateCompactSQLPrepared.Close()
+	if d.LastInsertID {
+		d.insertLastInsertIDSQLPrepared.Close()
+	} else {
+		d.insertSQLPrepared.Close()
+	}
+	d.fillSQLPrepared.Close()
+	d.getSizeSQLPrepared.Close()
+	d.DB.Close()
+}
+
 func getPrefixRange(prefix string) (start, end string) {
 	start = prefix
 	if strings.HasSuffix(prefix, "/") {

--- a/pkg/kine/drivers/generic_test.go
+++ b/pkg/kine/drivers/generic_test.go
@@ -14,7 +14,6 @@ import (
 type makeBackendFunc func(ctx context.Context, tb testing.TB) (server.Backend, *generic.Generic, error)
 
 func testCompaction(t *testing.T, makeBackend makeBackendFunc) {
-
 	t.Run("SmallDatabaseDeleteEntry", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx, cancel := context.WithCancel(context.Background())
@@ -23,8 +22,10 @@ func testCompaction(t *testing.T, makeBackend makeBackendFunc) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer backend.Wait()
-		defer dialect.DB.Close()
+		t.Cleanup(func() {
+			backend.Wait()
+			dialect.Close()
+		})
 
 		addEntries(ctx, dialect, 2)
 		deleteEntries(ctx, dialect, 1)
@@ -50,8 +51,10 @@ func testCompaction(t *testing.T, makeBackend makeBackendFunc) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer backend.Wait()
-		defer dialect.DB.Close()
+		t.Cleanup(func() {
+			backend.Wait()
+			dialect.Close()
+		})
 
 		addEntries(ctx, dialect, 10_000)
 		deleteEntries(ctx, dialect, 500)
@@ -79,8 +82,10 @@ func benchmarkCompaction(b *testing.B, makeBackend makeBackendFunc) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer backend.Wait()
-	defer dialect.DB.Close()
+	b.Cleanup(func() {
+		backend.Wait()
+		dialect.Close()
+	})
 
 	// Make sure there's enough rows deleted to have
 	// b.N rows to compact.

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -76,9 +76,8 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 		if err := grpcServer.Serve(listener); err != nil {
 			logrus.Errorf("Kine server shutdown: %v", err)
 		}
-		<-ctx.Done()
-		grpcServer.Stop()
 		listener.Close()
+		grpcServer.Stop()
 	}()
 
 	return ETCDConfig{
@@ -143,9 +142,8 @@ func ListenAndReturnBackend(ctx context.Context, config Config) (ETCDConfig, ser
 		if err := grpcServer.Serve(listener); err != nil {
 			logrus.Errorf("Kine server shutdown: %v", err)
 		}
-		<-ctx.Done()
-		grpcServer.Stop()
 		listener.Close()
+		grpcServer.Stop()
 	}()
 
 	return ETCDConfig{

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -49,10 +49,14 @@ type Dialect interface {
 	GetSize(ctx context.Context) (int64, error)
 	GetCompactInterval() time.Duration
 	GetPollInterval() time.Duration
+	Close()
 }
 
 func (s *SQLLog) Start(ctx context.Context) (err error) {
 	s.ctx = ctx
+	context.AfterFunc(ctx, func() {
+		s.d.Close()
+	})
 	return s.broadcaster.Start(s.startWatch)
 }
 

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -13,6 +13,7 @@ var (
 
 type Backend interface {
 	Start(ctx context.Context) error
+	Wait()
 	Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (int64, *KeyValue, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
+	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	kine_tls "github.com/canonical/k8s-dqlite/pkg/kine/tls"
 	"github.com/sirupsen/logrus"
 )
@@ -24,6 +25,8 @@ import (
 type Server struct {
 	// app is the dqlite application driving the server.
 	app *app.App
+
+	backend server.Backend
 
 	// kineConfig is the configuration to use for starting kine against the dqlite application.
 	kineConfig endpoint.Config
@@ -336,10 +339,13 @@ func (s *Server) Start(ctx context.Context) error {
 	logrus.WithFields(logrus.Fields{"id": s.app.ID(), "address": s.app.Address()}).Print("Started dqlite")
 
 	logrus.WithField("config", s.kineConfig).Debug("Starting kine")
-	if _, err := endpoint.Listen(ctx, s.kineConfig); err != nil {
+	_, backend, err := endpoint.ListenAndReturnBackend(ctx, s.kineConfig)
+	if err != nil {
 		return fmt.Errorf("failed to start kine: %w", err)
 	}
 	logrus.WithFields(logrus.Fields{"address": s.kineConfig.Listener, "database": s.kineConfig.Endpoint}).Print("Started kine")
+
+	s.backend = backend
 
 	go s.watchAvailableStorageSize(ctx)
 
@@ -357,6 +363,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return fmt.Errorf("failed to close dqlite app: %w", err)
 	}
 	close(s.mustStopCh)
+	s.backend.Wait()
 	return nil
 }
 

--- a/test/admission_test.go
+++ b/test/admission_test.go
@@ -16,94 +16,87 @@ import (
 // TestAdmissionControl puts heavy load on kine and expects that some requests are denied
 // by the admission control.
 func TestAdmissionControl(t *testing.T) {
-	ctx := context.Background()
-	client, _ := newKine(ctx, t, "admission-control-policy=limit", "admission-control-policy-limit-max-concurrent-txn=600", "admission-control-only-write-queries=true")
 	g := NewWithT(t)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, _ := newKine(ctx, t, "admission-control-policy=limit", "admission-control-policy-limit-max-concurrent-txn=600", "admission-control-only-write-queries=true")
+
 	// create a key space of 1000 items
-	{
-		for i := 0; i < 1000; i++ {
+	for i := 0; i < 1000; i++ {
+		key := fmt.Sprintf("Key-%d", i)
+		value := fmt.Sprintf("Value-%d", i)
+		createKey(ctx, g, client, key, value)
+	}
+
+	var wg sync.WaitGroup
+
+	var numSuccessfulWriterTxn = atomic.Uint64{}
+	var numSuccessfulReaderTxn = atomic.Uint64{}
+
+	reader := func(first int, last int) {
+		defer wg.Done()
+		for i := first; i < last; i++ {
 			key := fmt.Sprintf("Key-%d", i)
-			value := fmt.Sprintf("Value-%d", i)
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-				Then(clientv3.OpPut(key, value)).
-				Commit()
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
+			_, err := client.Get(ctx, key, clientv3.WithRange(""))
+			if err == nil {
+				numSuccessfulReaderTxn.Add(1)
+			}
 		}
 	}
 
-	t.Run("LatestRevision", func(t *testing.T) {
-		g := NewWithT(t)
-		var wg sync.WaitGroup
+	writer := func(first int, last int) {
+		defer wg.Done()
+		for i := first; i < last; i++ {
+			key := fmt.Sprintf("Key-%d", i)
+			new_value := fmt.Sprintf("New-Value-%d", i)
+			resp, err := client.Get(ctx, key, clientv3.WithRange(""))
+			if err != nil || len(resp.Kvs) == 0 {
+				t.Logf("Could not get %s\n", key)
+				continue
+			}
+			lastModRev := resp.Kvs[0].ModRevision
+			put_resp, err := client.Txn(ctx).
+				If(clientv3.Compare(clientv3.ModRevision(key), "=", lastModRev)).
+				Then(clientv3.OpPut(key, new_value)).
+				Else(clientv3.OpGet(key, clientv3.WithRange(""))).
+				Commit()
 
-		var numSuccessfulWriterTxn = atomic.Uint64{}
-		var numSuccessfulReaderTxn = atomic.Uint64{}
-
-		reader := func(first int, last int) {
-			defer wg.Done()
-			for i := first; i < last; i++ {
-				key := fmt.Sprintf("Key-%d", i)
-				_, err := client.Get(ctx, key, clientv3.WithRange(""))
-				if err == nil {
-					numSuccessfulReaderTxn.Add(1)
-				}
+			if err == nil && put_resp.Succeeded == true {
+				numSuccessfulWriterTxn.Add(1)
+				break
 			}
 		}
+	}
 
-		writer := func(first int, last int) {
-			defer wg.Done()
-			for i := first; i < last; i++ {
-				key := fmt.Sprintf("Key-%d", i)
-				new_value := fmt.Sprintf("New-Value-%d", i)
-				resp, err := client.Get(ctx, key, clientv3.WithRange(""))
-				if err != nil || len(resp.Kvs) == 0 {
-					t.Logf("Could not get %s\n", key)
-					continue
-				}
-				lastModRev := resp.Kvs[0].ModRevision
-				put_resp, err := client.Txn(ctx).
-					If(clientv3.Compare(clientv3.ModRevision(key), "=", lastModRev)).
-					Then(clientv3.OpPut(key, new_value)).
-					Else(clientv3.OpGet(key, clientv3.WithRange(""))).
-					Commit()
+	readers := 50
+	readers_replication := 3
+	read_entries := 1000 / readers
+	writers := 500
+	writers_replication := 10
+	write_entries := 1000 / writers
+	wg.Add(readers*readers_replication + writers*writers_replication)
 
-				if err == nil && put_resp.Succeeded == true {
-					numSuccessfulWriterTxn.Add(1)
-					break
-				}
-			}
+	start := time.Now()
+	for i := 0; i < readers; i++ {
+		for j := 0; j < readers_replication; j++ {
+			go reader(i*read_entries, (i+1)*read_entries)
 		}
-
-		readers := 50
-		readers_replication := 3
-		read_entries := 1000 / readers
-		writers := 500
-		writers_replication := 10
-		write_entries := 1000 / writers
-		wg.Add(readers*readers_replication + writers*writers_replication)
-
-		start := time.Now()
-		for i := 0; i < readers; i++ {
-			for j := 0; j < readers_replication; j++ {
-				go reader(i*read_entries, (i+1)*read_entries)
-			}
+	}
+	for i := 0; i < writers; i++ {
+		for j := 0; j < writers_replication; j++ {
+			go writer(i*write_entries, (i+1)*write_entries)
 		}
-		for i := 0; i < writers; i++ {
-			for j := 0; j < writers_replication; j++ {
-				go writer(i*write_entries, (i+1)*write_entries)
-			}
-		}
+	}
 
-		wg.Wait()
-		duration := time.Since(start)
+	wg.Wait()
+	duration := time.Since(start)
 
-		t.Logf("Executed 1000 queries in %.2f seconds\n", duration.Seconds())
-		// It is expected that some queries are denied by the admission control due to the load.
-		g.Expect(numSuccessfulWriterTxn.Load()).To(BeNumerically("<", writers*writers_replication*write_entries))
+	t.Logf("Executed 1000 queries in %.2f seconds\n", duration.Seconds())
+	// It is expected that some queries are denied by the admission control due to the load.
+	g.Expect(numSuccessfulWriterTxn.Load()).To(BeNumerically("<", writers*writers_replication*write_entries))
 
-		// read queries should be ignored by the admission control
-		g.Expect(numSuccessfulReaderTxn.Load()).To(BeNumerically("==", readers*readers_replication*read_entries))
-	})
+	// read queries should be ignored by the admission control
+	g.Expect(numSuccessfulReaderTxn.Load()).To(BeNumerically("==", readers*readers_replication*read_entries))
 }

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -11,40 +11,35 @@ import (
 
 // TestCreate is unit testing for the create operation.
 func TestCreate(t *testing.T) {
-	ctx := context.Background()
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, t)
 
-	t.Run("CreateOne", func(t *testing.T) {
-		g := NewWithT(t)
-		resp, err := client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-			Then(clientv3.OpPut("testKey", "testValue")).
-			Commit()
+	createKey(ctx, g, client, "testKey", "testValue")
 
-		g.Expect(err).To(BeNil())
-		g.Expect(resp.Succeeded).To(BeTrue())
-	})
+	resp, err := client.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
+		Then(clientv3.OpPut("testKey", "testValue2")).
+		Commit()
 
-	t.Run("CreateExistingFails", func(t *testing.T) {
-		g := NewWithT(t)
-		resp, err := client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision("testKey"), "=", 0)).
-			Then(clientv3.OpPut("testKey", "testValue2")).
-			Commit()
-
-		g.Expect(err).To(BeNil())
-		g.Expect(resp.Succeeded).To(BeFalse())
-	})
+	g.Expect(err).To(BeNil())
+	g.Expect(resp.Succeeded).To(BeFalse())
 }
 
 // BenchmarkCreate is a benchmark for the Create operation.
 func BenchmarkCreate(b *testing.B) {
 	b.StopTimer()
-	ctx := context.Background()
+	g := NewWithT(b)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, b)
 
 	b.StartTimer()
-	g := NewWithT(b)
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
@@ -52,7 +47,7 @@ func BenchmarkCreate(b *testing.B) {
 	}
 }
 
-func createKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
+func createKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) int64 {
 	resp, err := client.Txn(ctx).
 		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
 		Then(clientv3.OpPut(key, value)).
@@ -60,4 +55,7 @@ func createKey(ctx context.Context, g Gomega, client *clientv3.Client, key strin
 
 	g.Expect(err).To(BeNil())
 	g.Expect(resp.Succeeded).To(BeTrue())
+	g.Expect(resp.Responses).To(HaveLen(1))
+	g.Expect(resp.Responses[0].GetResponsePut()).NotTo(BeNil())
+	return resp.Responses[0].GetResponsePut().Header.Revision
 }

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -11,7 +11,9 @@ import (
 
 // TestDelete is unit testing for the delete operation.
 func TestDelete(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, t)
 
 	// Calling the delete method outside a transaction should fail in kine
@@ -49,10 +51,13 @@ func TestDelete(t *testing.T) {
 // BenchmarkDelete is a benchmark for the delete operation.
 func BenchmarkDelete(b *testing.B) {
 	b.StopTimer()
-	ctx := context.Background()
+	g := NewWithT(b)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, b)
 
-	g := NewWithT(b)
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -10,7 +10,9 @@ import (
 
 // TestGet is unit testing for the Get operation.
 func TestGet(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, t)
 
 	t.Run("FailNotFound", func(t *testing.T) {
@@ -46,100 +48,47 @@ func TestGet(t *testing.T) {
 		g := NewWithT(t)
 		key := "testKeySuccess"
 
-		// Create a key
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-				Then(clientv3.OpPut(key, "testValue")).
-				Commit()
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-		}
+		createKey(ctx, g, client, key, "testValue")
 
-		// Get key
-		{
-			resp, err := client.Get(ctx, key, clientv3.WithRange(""))
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(1))
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte(key)))
-			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
-		}
+		resp, err := client.Get(ctx, key, clientv3.WithRange(""))
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(1))
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte(key)))
+		g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
 	})
 
 	t.Run("KeyRevision", func(t *testing.T) {
 		g := NewWithT(t)
 		key := "testKeyRevision"
-		var lastModRev int64
-
-		// Create a key with a known value
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-				Then(clientv3.OpPut(key, "testValue")).
-				Commit()
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
-		}
+		lastModRev := createKey(ctx, g, client, key, "testValue")
 
 		// Get the key's version
-		{
-			resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Count).To(Equal(int64(0)))
-		}
+		resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Count).To(Equal(int64(0)))
 
-		// Update the key
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", lastModRev)).
-				Then(clientv3.OpPut(key, "testValue2")).
-				Else(clientv3.OpGet(key, clientv3.WithRange(""))).
-				Commit()
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-		}
+		updateRevision(ctx, g, client, key, lastModRev, "testValue2")
 
 		// Get the updated key
-		{
-			resp, err := client.Get(ctx, key, clientv3.WithCountOnly())
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
-			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
-		}
+		resp, err = client.Get(ctx, key, clientv3.WithCountOnly())
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
+		g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
 	})
 
 	t.Run("SuccessWithPrefix", func(t *testing.T) {
 		g := NewWithT(t)
 
 		// Create keys with prefix
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("prefix/testKey1"), "=", 0)).
-				Then(clientv3.OpPut("prefix/testKey1", "testValue1")).
-				Commit()
+		createKey(ctx, g, client, "prefix/testKey1", "testValue1")
+		createKey(ctx, g, client, "prefix/testKey2", "testValue2")
 
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
+		resp, err := client.Get(ctx, "prefix", clientv3.WithPrefix())
 
-			resp, err = client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("prefix/testKey2"), "=", 0)).
-				Then(clientv3.OpPut("prefix/testKey2", "testValue2")).
-				Commit()
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-		}
-
-		// Get keys with prefix
-		{
-			resp, err := client.Get(ctx, "prefix", clientv3.WithPrefix())
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(2))
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("prefix/testKey1")))
-			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("prefix/testKey2")))
-		}
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(2))
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("prefix/testKey1")))
+		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("prefix/testKey2")))
 	})
 
 	t.Run("FailNotFound", func(t *testing.T) {
@@ -147,32 +96,24 @@ func TestGet(t *testing.T) {
 		key := "testKeyFailNotFound"
 
 		// Delete key
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-				Then(clientv3.OpDelete(key)).
-				Else(clientv3.OpGet(key)).
-				Commit()
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-		}
+		deleteKey(ctx, g, client, key)
 
 		// Get key
-		{
-			resp, err := client.Get(ctx, key, clientv3.WithRange(""))
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(BeEmpty())
-		}
+		resp, err := client.Get(ctx, key, clientv3.WithRange(""))
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(BeEmpty())
 	})
 }
 
 // BenchmarkGet is a benchmark for the Get operation.
 func BenchmarkGet(b *testing.B) {
 	b.StopTimer()
-	ctx := context.Background()
-	client, _ := newKine(ctx, b)
 	g := NewWithT(b)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, _ := newKine(ctx, b)
 
 	// create a kv
 	createKey(ctx, g, client, "testKey", "testValue")

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -12,7 +12,9 @@ import (
 
 // TestList is the unit test for List operation.
 func TestList(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, t)
 
 	t.Run("ListSuccess", func(t *testing.T) {
@@ -21,14 +23,7 @@ func TestList(t *testing.T) {
 		// Create some keys
 		keys := shuffleList([]string{"/key/1", "/key/2", "/key/3", "/key/4", "/key/5"})
 		for _, key := range keys {
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-				Then(clientv3.OpPut(key, "value")).
-				Commit()
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-			g.Expect(resp.Header.Revision).ToNot(BeZero())
+			createKey(ctx, g, client, key, "value")
 		}
 
 		t.Run("ListAll", func(t *testing.T) {
@@ -102,14 +97,7 @@ func TestList(t *testing.T) {
 			// Create some keys
 			keys := []string{"key/sub/2", "key/sub/1", "key/other/1"}
 			for _, key := range keys {
-				resp, err := client.Txn(ctx).
-					If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-					Then(clientv3.OpPut(key, "value")).
-					Commit()
-
-				g.Expect(err).To(BeNil())
-				g.Expect(resp.Succeeded).To(BeTrue())
-				g.Expect(resp.Header.Revision).ToNot(BeZero())
+				createKey(ctx, g, client, key, "value")
 			}
 
 			// Get a list of all the keys sice they have '/key' prefix
@@ -161,14 +149,7 @@ func TestList(t *testing.T) {
 				// Create some keys
 				keys := []string{"/revkey/1"}
 				for _, key := range keys {
-					resp, err := client.Txn(ctx).
-						If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-						Then(clientv3.OpPut(key, "value")).
-						Commit()
-
-					g.Expect(err).To(BeNil())
-					g.Expect(resp.Succeeded).To(BeTrue())
-					g.Expect(resp.Header.Revision).ToNot(BeZero())
+					createKey(ctx, g, client, key, "value")
 				}
 			})
 
@@ -226,9 +207,12 @@ func TestList(t *testing.T) {
 // BenchmarkList is a benchmark for the Get operation.
 func BenchmarkList(b *testing.B) {
 	b.StopTimer()
-	ctx := context.Background()
-	client, _ := newKine(ctx, b)
 	g := NewWithT(b)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, _ := newKine(ctx, b)
 
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key/%d", i)

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -12,51 +12,29 @@ import (
 
 // TestUpdate is unit testing for the update operation.
 func TestUpdate(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, t)
 
 	// Testing that update can create a new key if ModRevision is 0
 	t.Run("UpdateNewKey", func(t *testing.T) {
 		g := NewWithT(t)
 
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("updateNewKey"), "=", 0)).
-				Then(clientv3.OpPut("updateNewKey", "testValue")).
-				Else(clientv3.OpGet("updateNewKey", clientv3.WithRange(""))).
-				Commit()
+		createKey(ctx, g, client, "updateNewKey", "testValue")
 
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-		}
-
-		{
-			resp, err := client.Get(ctx, "updateNewKey", clientv3.WithRange(""))
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(1))
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("updateNewKey")))
-			g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
-			g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(resp.Kvs[0].CreateRevision)))
-		}
+		resp, err := client.Get(ctx, "updateNewKey", clientv3.WithRange(""))
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(1))
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("updateNewKey")))
+		g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue")))
+		g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(resp.Kvs[0].CreateRevision)))
 	})
 
 	t.Run("UpdateExisting", func(t *testing.T) {
 		g := NewWithT(t)
 
-		var lastModRev int64
-
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("updateExistingKey"), "=", 0)).
-				Then(clientv3.OpPut("updateExistingKey", "testValue1")).
-				Commit()
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-			g.Expect(resp.Responses).To(HaveLen(1))
-			g.Expect(resp.Responses[0].GetResponsePut()).NotTo(BeNil())
-			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
-		}
+		lastModRev := createKey(ctx, g, client, "updateExistingKey", "testValue1")
 
 		{
 			resp, err := client.Txn(ctx).
@@ -101,20 +79,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("UpdateOldRevisionFails", func(t *testing.T) {
 		g := NewWithT(t)
 
-		var lastModRev int64
-
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision("updateOldRevKey"), "=", 0)).
-				Then(clientv3.OpPut("updateOldRevKey", "testValue1")).
-				Commit()
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-			g.Expect(resp.Responses).To(HaveLen(1))
-			g.Expect(resp.Responses[0].GetResponsePut()).NotTo(BeNil())
-			lastModRev = resp.Responses[0].GetResponsePut().Header.Revision
-		}
+		lastModRev := createKey(ctx, g, client, "updateOldRevKey", "testValue1")
 
 		{
 			resp, err := client.Txn(ctx).
@@ -139,9 +104,7 @@ func TestUpdate(t *testing.T) {
 			g.Expect(resp.Responses).To(HaveLen(1))
 			g.Expect(resp.Responses[0].GetResponseRange()).ToNot(BeNil())
 		}
-
 	})
-
 }
 
 func addSameEntries(ctx context.Context, g Gomega, client *clientv3.Client, numEntries int, create_first bool) {
@@ -192,14 +155,15 @@ func addEntry(ctx context.Context, g Gomega, client *clientv3.Client, key string
 // BenchmarkUpdate is a benchmark for the Update operation.
 func BenchmarkUpdate(b *testing.B) {
 	b.StopTimer()
-	ctx := context.Background()
-	client, _ := newKine(ctx, b)
-
 	g := NewWithT(b)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, _ := newKine(ctx, b)
+
 	b.StartTimer()
-	var lastModRev int64 = 0
-	for i := 0; i < b.N; i++ {
+	for i, lastModRev := 0, int64(0); i < b.N; i++ {
 		value := fmt.Sprintf("value-%d", i)
 		lastModRev = updateRevision(ctx, g, client, "benchKey", lastModRev, value)
 	}

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -45,11 +45,14 @@ func newKine(ctx context.Context, tb testing.TB, qs ...string) (*clientv3.Client
 	}
 	config, backend, err := endpoint.ListenAndReturnBackend(ctx, endpointConfig)
 	if err != nil {
-		panic(err)
+		tb.Fatal(err)
 	}
+	tb.Cleanup(func() {
+		backend.Wait()
+	})
 	tlsConfig, err := config.TLSConfig.ClientConfig()
 	if err != nil {
-		panic(err)
+		tb.Fatal(err)
 	}
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{endpointConfig.Listener},
@@ -57,7 +60,7 @@ func newKine(ctx context.Context, tb testing.TB, qs ...string) (*clientv3.Client
 		TLS:         tlsConfig,
 	})
 	if err != nil {
-		panic(err)
+		tb.Fatal(err)
 	}
 	return client, backend
 }

--- a/test/util_test_dqlite.go
+++ b/test/util_test_dqlite.go
@@ -21,10 +21,10 @@ func makeEndpointConfig(ctx context.Context, tb testing.TB) endpoint.Config {
 
 	app, err := app.New(dir, app.WithAddress(fmt.Sprintf("127.0.0.1:%d", 59090+nextIdx)))
 	if err != nil {
-		panic(fmt.Errorf("failed to create dqlite app: %w", err))
+		tb.Fatal(fmt.Errorf("failed to create dqlite app: %w", err))
 	}
 	if err := app.Ready(ctx); err != nil {
-		panic(fmt.Errorf("failed to initialize dqlite: %w", err))
+		tb.Fatal(fmt.Errorf("failed to initialize dqlite: %w", err))
 	}
 	tb.Cleanup(func() {
 		app.Close()

--- a/test/watch_test.go
+++ b/test/watch_test.go
@@ -10,7 +10,9 @@ import (
 
 // TestWatch is unit testing for the Watch operation.
 func TestWatch(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	client, _ := newKine(ctx, t)
 
 	var (
@@ -35,15 +37,7 @@ func TestWatch(t *testing.T) {
 		g := NewWithT(t)
 
 		// create a key
-		{
-			resp, err := client.Txn(ctx).
-				If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
-				Then(clientv3.OpPut(key, value)).
-				Commit()
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Succeeded).To(BeTrue())
-		}
+		createKey(ctx, g, client, key, value)
 
 		// receive event
 		t.Run("Receive", func(t *testing.T) {


### PR DESCRIPTION
This PR adds a way for the Server to wait for other services (like the Backend, the event polling, the cleanup for ttl, the watchers, etc...) to end during shutdown.

It is useful mainly during tests/benchmarks so that we are sure that once the test is over, no service is still running.