### PR TITLE
Remove UpdateSameKeyLinearity

### DIFF
--- a/test/update_test.go
+++ b/test/update_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -78,24 +77,6 @@ func TestUpdate(t *testing.T) {
 			g.Expect(resp.Kvs[0].ModRevision).To(BeNumerically(">", resp.Kvs[0].CreateRevision))
 		}
 	})
-	t.Run("UpdateSameKeyLinearity", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// Add a large number of entries, two times and
-		// it should take approximately same amout of time
-		numAddEntries := 1000
-
-		startFirst := time.Now()
-		addSameEntries(ctx, g, client, numAddEntries, true)
-		durationFirstBatch := time.Since(startFirst)
-
-		startSecond := time.Now()
-		addSameEntries(ctx, g, client, numAddEntries, false)
-		durationSecondBatch := time.Since(startSecond)
-
-		g.Expect(durationSecondBatch <= durationFirstBatch*2).To(BeTrue())
-
-	})
 
 	// Trying to update an old revision(in compare) should fail
 	t.Run("UpdateOldRevisionFails", func(t *testing.T) {
@@ -142,19 +123,6 @@ func TestUpdate(t *testing.T) {
 
 	})
 
-}
-
-func addSameEntries(ctx context.Context, g Gomega, client *clientv3.Client, numEntries int, create_first bool) {
-	for i := 0; i < numEntries; i++ {
-		key := "testkey-same"
-		value := fmt.Sprintf("value-%d", i)
-
-		if i != 0 || !create_first {
-			updateEntry(ctx, g, client, key, value)
-		} else {
-			addEntry(ctx, g, client, key, value)
-		}
-	}
 }
 
 func updateEntry(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {


### PR DESCRIPTION
This test is too imprecise to be useful and making it precise is unpractical. Right now if the second batch takes *twice* the time (leading to an exponential growth) the test still pass.

It is also the test that takes the longest amount of time in the whole pipeline.
