### PR TITLE
Simplify integration tests

### DIFF
--- a/pkg/kine/drivers/generic/admission_test.go
+++ b/pkg/kine/drivers/generic/admission_test.go
@@ -4,67 +4,66 @@ import (
 	"context"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestAllowAllPolicy_Admit(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewWithT(t)
 	policy := &allowAllPolicy{}
 
 	callOnFinish, err := policy.Admit(context.Background(), "get_size_sql")
 
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(callOnFinish).ToNot(gomega.BeNil())
+	g.Expect(err).To(BeNil())
+	g.Expect(callOnFinish).ToNot(BeNil())
 }
 
 func TestLimitPolicy_Admit(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewWithT(t)
 	policy := newLimitPolicy(false, 2)
 
 	// First two should succeed
 	done1, err := policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(done1).ToNot(gomega.BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done1).ToNot(BeNil())
 	done2, err := policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(done2).ToNot(gomega.BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done2).ToNot(BeNil())
 
 	// Third should be denied
 	done3, err := policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 	// should still return a valid function as callers otherwise might segfault if they not check for nil.
-	g.Expect(done3).ToNot(gomega.BeNil())
+	g.Expect(done3).ToNot(BeNil())
 
 	// Complete a call - now the next query should be admitted again.
 	done1()
 	_, err = policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(done3).ToNot(gomega.BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done3).ToNot(BeNil())
 }
 
 func TestLimitPolicy_Admit_OnlyCheckWriteQueries(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewWithT(t)
 	policy := newLimitPolicy(true, 2)
 
 	// Read queries should always succeed
 	_, err := policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(err).ToNot(HaveOccurred())
 	_, err = policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(err).ToNot(HaveOccurred())
 	_, err = policy.Admit(context.Background(), "get_size_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// write queries should be evaluated, thus fail after second call
 	done1, err := policy.Admit(context.Background(), "insert_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(err).ToNot(HaveOccurred())
 	_, err = policy.Admit(context.Background(), "delete_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(err).ToNot(HaveOccurred())
 	_, err = policy.Admit(context.Background(), "fill_sql")
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 
 	// Another write query should be possible after one is done
 	done1()
 	_, err = policy.Admit(context.Background(), "fill_sql")
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
+	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -67,7 +67,7 @@ func TestGet(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		g.Expect(resp.Count).To(Equal(int64(0)))
 
-		updateRevision(ctx, g, client, key, lastModRev, "testValue2")
+		updateRev(ctx, g, client, key, lastModRev, "testValue2")
 
 		// Get the updated key
 		resp, err = client.Get(ctx, key, clientv3.WithCountOnly())

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -19,14 +18,14 @@ func TestList(t *testing.T) {
 
 	client, _ := newKine(ctx, t)
 
-	keys := shuffleList([]string{"/key/1", "/key/2", "/key/3", "/key/4", "/key/5"})
+	keys := []string{"/key/5", "/key/4", "/key/3", "/key/2", "/key/1"}
 	for _, key := range keys {
 		createKey(ctx, g, client, key, "value")
 	}
 
 	t.Run("ListAll", func(t *testing.T) {
 		g := NewWithT(t)
-		// Get a list of all the keys
+
 		resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
 
 		g.Expect(err).To(BeNil())
@@ -86,13 +85,12 @@ func TestList(t *testing.T) {
 
 	t.Run("ListPrefix", func(t *testing.T) {
 		g := NewWithT(t)
-		// Create some keys
+
 		keys := []string{"key/sub/2", "key/sub/1", "key/other/1"}
 		for _, key := range keys {
 			createKey(ctx, g, client, key, "value")
 		}
 
-		// Get a list of all the keys sice they have '/key' prefix
 		resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
 
 		g.Expect(err).To(BeNil())
@@ -104,7 +102,6 @@ func TestList(t *testing.T) {
 		g.Expect(resp.Kvs[3].Key).To(Equal([]byte("/key/4")))
 		g.Expect(resp.Kvs[4].Key).To(Equal([]byte("/key/5")))
 
-		// Get a list of all the keys sice they have '/key/sub' prefix
 		resp, err = client.Get(ctx, "key/sub", clientv3.WithPrefix())
 
 		g.Expect(err).To(BeNil())
@@ -113,7 +110,6 @@ func TestList(t *testing.T) {
 		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/sub/1")))
 		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("key/sub/2")))
 
-		// Get a list of all the keys sice they have '/key/other' prefix
 		resp, err = client.Get(ctx, "key/other", clientv3.WithPrefix())
 
 		g.Expect(err).To(BeNil())
@@ -125,7 +121,6 @@ func TestList(t *testing.T) {
 	t.Run("ListRange", func(t *testing.T) {
 		g := NewWithT(t)
 
-		// Get a list of with key/1, as only key/1 falls within the specified range.
 		resp, err := client.Get(ctx, "/key/1", clientv3.WithRange(""))
 
 		g.Expect(err).To(BeNil())
@@ -199,18 +194,4 @@ func BenchmarkList(b *testing.B) {
 		g.Expect(err).To(BeNil())
 		g.Expect(resp.Kvs).To(HaveLen(b.N))
 	}
-}
-
-func shuffleList[T any](vals []T) []T {
-	if len(vals) == 0 {
-		return vals
-	}
-
-	perm := rand.Perm(len(vals))
-	shuffled := make([]T, 0, len(vals))
-	for _, i := range perm {
-		shuffled = append(shuffled, vals[perm[i]])
-	}
-
-	return shuffled
 }

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -12,175 +12,167 @@ import (
 
 // TestList is the unit test for List operation.
 func TestList(t *testing.T) {
+	g := NewWithT(t)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	client, _ := newKine(ctx, t)
 
-	t.Run("ListSuccess", func(t *testing.T) {
+	keys := shuffleList([]string{"/key/1", "/key/2", "/key/3", "/key/4", "/key/5"})
+	for _, key := range keys {
+		createKey(ctx, g, client, key, "value")
+	}
+
+	t.Run("ListAll", func(t *testing.T) {
+		g := NewWithT(t)
+		// Get a list of all the keys
+		resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(5))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
+		g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
+		g.Expect(resp.Kvs[3].Key).To(Equal([]byte("/key/4")))
+		g.Expect(resp.Kvs[4].Key).To(Equal([]byte("/key/5")))
+	})
+
+	t.Run("ListAllLimit", func(t *testing.T) {
 		g := NewWithT(t)
 
+		resp, err := client.Get(ctx, "/key", clientv3.WithPrefix(), clientv3.WithLimit(2))
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(2))
+		g.Expect(resp.More).To(BeTrue())
+		g.Expect(resp.Count).To(Equal(int64(5)))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
+
+		rev := resp.Header.Revision
+
+		// Inspired from https://github.com/kubernetes/kubernetes/blob/3f4d3b67682335db510f85deb65b322127a3a0a1/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L788-L793
+		// Key is "last_key" + "\x00", and we use the prefix range end
+		resp, err = client.Get(ctx, "/key/2\x00",
+			clientv3.WithRange(clientv3.GetPrefixRangeEnd("/key")),
+			clientv3.WithLimit(2),
+			clientv3.WithRev(rev))
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(2))
+		g.Expect(resp.More).To(BeTrue())
+		g.Expect(resp.Count).To(Equal(int64(3)))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/3")))
+		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/4")))
+
+		rev = resp.Header.Revision
+
+		resp, err = client.Get(ctx, "/key/4\x00",
+			clientv3.WithRange(clientv3.GetPrefixRangeEnd("/key")),
+			clientv3.WithLimit(2),
+			clientv3.WithRev(rev))
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(1))
+		g.Expect(resp.More).To(BeFalse())
+		g.Expect(resp.Count).To(Equal(int64(1)))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/5")))
+	})
+
+	t.Run("ListPrefix", func(t *testing.T) {
+		g := NewWithT(t)
 		// Create some keys
-		keys := shuffleList([]string{"/key/1", "/key/2", "/key/3", "/key/4", "/key/5"})
+		keys := []string{"key/sub/2", "key/sub/1", "key/other/1"}
 		for _, key := range keys {
 			createKey(ctx, g, client, key, "value")
 		}
 
-		t.Run("ListAll", func(t *testing.T) {
+		// Get a list of all the keys sice they have '/key' prefix
+		resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(5))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
+		g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
+		g.Expect(resp.Kvs[3].Key).To(Equal([]byte("/key/4")))
+		g.Expect(resp.Kvs[4].Key).To(Equal([]byte("/key/5")))
+
+		// Get a list of all the keys sice they have '/key/sub' prefix
+		resp, err = client.Get(ctx, "key/sub", clientv3.WithPrefix())
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(2))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/sub/1")))
+		g.Expect(resp.Kvs[1].Key).To(Equal([]byte("key/sub/2")))
+
+		// Get a list of all the keys sice they have '/key/other' prefix
+		resp, err = client.Get(ctx, "key/other", clientv3.WithPrefix())
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(1))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/other/1")))
+	})
+
+	t.Run("ListRange", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Get a list of with key/1, as only key/1 falls within the specified range.
+		resp, err := client.Get(ctx, "/key/1", clientv3.WithRange(""))
+
+		g.Expect(err).To(BeNil())
+		g.Expect(resp.Kvs).To(HaveLen(1))
+		g.Expect(resp.Header.Revision).ToNot(BeZero())
+		g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+	})
+
+	t.Run("ListRevision", func(t *testing.T) {
+		g := NewWithT(t)
+
+		const key = "/revkey/1"
+		createRev := createKey(ctx, g, client, key, "value")
+
+		const updates = 50
+		for i, rev := 0, createRev; i < updates; i++ {
+			rev = updateRev(ctx, g, client, key, rev, fmt.Sprintf("val-%d", i))
+		}
+
+		t.Run("NoRevision", func(t *testing.T) {
 			g := NewWithT(t)
-			// Get a list of all the keys
-			resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
 
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(5))
-			g.Expect(resp.Header.Revision).ToNot(BeZero())
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
-			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
-			g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
-			g.Expect(resp.Kvs[3].Key).To(Equal([]byte("/key/4")))
-			g.Expect(resp.Kvs[4].Key).To(Equal([]byte("/key/5")))
-		})
-
-		t.Run("ListAllLimit", func(t *testing.T) {
-			var revision int64
-			t.Run("FirstPage", func(t *testing.T) {
-				g := NewWithT(t)
-
-				resp, err := client.Get(ctx, "/key", clientv3.WithPrefix(), clientv3.WithLimit(2))
-
-				g.Expect(err).To(BeNil())
-				g.Expect(resp.Kvs).To(HaveLen(2))
-				g.Expect(resp.More).To(BeTrue())
-				g.Expect(resp.Count).To(Equal(int64(5)))
-				g.Expect(resp.Header.Revision).ToNot(BeZero())
-				g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
-				g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
-
-				revision = resp.Header.Revision
-			})
-
-			t.Run("SecondPage", func(t *testing.T) {
-				g := NewWithT(t)
-
-				// Inspired from https://github.com/kubernetes/kubernetes/blob/3f4d3b67682335db510f85deb65b322127a3a0a1/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L788-L793
-				// Key is "last_key" + "\x00", and we use the prefix range end
-				resp, err := client.Get(ctx, "/key/2\x00", clientv3.WithRange(clientv3.GetPrefixRangeEnd("/key")), clientv3.WithLimit(2), clientv3.WithRev(revision))
-
-				g.Expect(err).To(BeNil())
-				g.Expect(resp.Kvs).To(HaveLen(2))
-				g.Expect(resp.More).To(BeTrue())
-				g.Expect(resp.Count).To(Equal(int64(3)))
-				g.Expect(resp.Header.Revision).ToNot(BeZero())
-				g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/3")))
-				g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/4")))
-
-				revision = resp.Header.Revision
-			})
-
-			t.Run("ThirdPage", func(t *testing.T) {
-				g := NewWithT(t)
-
-				// Get a list of all the keys
-				resp, err := client.Get(ctx, "/key/4\x00", clientv3.WithRange(clientv3.GetPrefixRangeEnd("/key")), clientv3.WithLimit(2), clientv3.WithRev(revision))
-
-				g.Expect(err).To(BeNil())
-				g.Expect(resp.Kvs).To(HaveLen(1))
-				g.Expect(resp.More).To(BeFalse())
-				g.Expect(resp.Count).To(Equal(int64(1)))
-				g.Expect(resp.Header.Revision).ToNot(BeZero())
-				g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/5")))
-			})
-		})
-
-		t.Run("ListPrefix", func(t *testing.T) {
-			g := NewWithT(t)
-			// Create some keys
-			keys := []string{"key/sub/2", "key/sub/1", "key/other/1"}
-			for _, key := range keys {
-				createKey(ctx, g, client, key, "value")
-			}
-
-			// Get a list of all the keys sice they have '/key' prefix
-			resp, err := client.Get(ctx, "/key", clientv3.WithPrefix())
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(5))
-			g.Expect(resp.Header.Revision).ToNot(BeZero())
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
-			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("/key/2")))
-			g.Expect(resp.Kvs[2].Key).To(Equal([]byte("/key/3")))
-			g.Expect(resp.Kvs[3].Key).To(Equal([]byte("/key/4")))
-			g.Expect(resp.Kvs[4].Key).To(Equal([]byte("/key/5")))
-
-			// Get a list of all the keys sice they have '/key/sub' prefix
-			resp, err = client.Get(ctx, "key/sub", clientv3.WithPrefix())
-
-			g.Expect(err).To(BeNil())
-			g.Expect(resp.Kvs).To(HaveLen(2))
-			g.Expect(resp.Header.Revision).ToNot(BeZero())
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/sub/1")))
-			g.Expect(resp.Kvs[1].Key).To(Equal([]byte("key/sub/2")))
-
-			// Get a list of all the keys sice they have '/key/other' prefix
-			resp, err = client.Get(ctx, "key/other", clientv3.WithPrefix())
-
+			resp, err := client.Get(ctx, "/revkey/", clientv3.WithPrefix())
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs).To(HaveLen(1))
-			g.Expect(resp.Header.Revision).ToNot(BeZero())
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("key/other/1")))
+			g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(createRev + updates)))
+			g.Expect(resp.Count).To(Equal(int64(1)))
 		})
 
-		t.Run("ListRange", func(t *testing.T) {
+		t.Run("OldRevision", func(t *testing.T) {
 			g := NewWithT(t)
 
-			// Get a list of with key/1, as only key/1 falls within the specified range.
-			resp, err := client.Get(ctx, "/key/1", clientv3.WithRange(""))
-
+			resp, err := client.Get(ctx, "/revkey/", clientv3.WithPrefix(), clientv3.WithRev(createRev+30))
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.Kvs).To(HaveLen(1))
-			g.Expect(resp.Header.Revision).ToNot(BeZero())
-			g.Expect(resp.Kvs[0].Key).To(Equal([]byte("/key/1")))
+			g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(createRev + 30)))
+			g.Expect(resp.Count).To(Equal(int64(1)))
 		})
 
-		t.Run("ListRevision", func(t *testing.T) {
+		t.Run("LaterRevision", func(t *testing.T) {
 			g := NewWithT(t)
 
-			// Create some keys
-			const key = "/revkey/1"
-			initialRevision := createKey(ctx, g, client, key, "value")
-
-			const updates = 50
-			for i := 0; i < updates; i++ {
-				updateKey(ctx, g, client, key, fmt.Sprintf("val-%d", i))
-			}
-
-			t.Run("List", func(t *testing.T) {
-				t.Run("NoRevision", func(t *testing.T) {
-					g := NewWithT(t)
-					resp, err := client.Get(ctx, "/revkey/", clientv3.WithPrefix())
-					g.Expect(err).To(BeNil())
-					g.Expect(resp.Kvs).To(HaveLen(1))
-					g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(initialRevision + updates)))
-					g.Expect(resp.Count).To(Equal(int64(1)))
-				})
-
-				t.Run("OldRevision", func(t *testing.T) {
-					g := NewWithT(t)
-					resp, err := client.Get(ctx, "/revkey/", clientv3.WithPrefix(), clientv3.WithRev(initialRevision+30))
-					g.Expect(err).To(BeNil())
-					g.Expect(resp.Kvs).To(HaveLen(1))
-					g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(initialRevision + 30)))
-					g.Expect(resp.Count).To(Equal(int64(1)))
-				})
-				t.Run("LaterRevision", func(t *testing.T) {
-					g := NewWithT(t)
-					resp, err := client.Get(ctx, "/revkey/", clientv3.WithPrefix(), clientv3.WithRev(initialRevision+100))
-					g.Expect(err).To(BeNil())
-					g.Expect(resp.Kvs).To(HaveLen(1))
-					g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(initialRevision + updates)))
-					g.Expect(resp.Count).To(Equal(int64(1)))
-				})
-			})
+			resp, err := client.Get(ctx, "/revkey/", clientv3.WithPrefix(), clientv3.WithRev(createRev+100))
+			g.Expect(err).To(BeNil())
+			g.Expect(resp.Kvs).To(HaveLen(1))
+			g.Expect(resp.Kvs[0].ModRevision).To(Equal(int64(createRev + updates)))
+			g.Expect(resp.Count).To(Equal(int64(1)))
 		})
 	})
 }


### PR DESCRIPTION
This PR aims at reducing the boilerplate for tests and benchmarks. In that direction it:
 - aligns the names of the utility function (now consistently called `{create,update,delete}Key`)
 - tries to use them everywhere possible
 - aligns the usage of gomega for the admission test
 - removes unused helper functions

From a functionality level, it also removes same-nesting inter-test dependencies which might break the tests if the run filters them (very present in the list tests). This has also a nice effect of reducing a bit indentation.

