### PR TITLE
Stable benchmarks

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Dqlite
         run: |
           sudo add-apt-repository -y ppa:dqlite/dev 
-          sudo apt install dqlite-tools
+          sudo apt install libdqlite-dev
 
       - name: Run benchmarks
         run: |

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+env:
+  BENCH_COUNT: 7
+
 jobs:
   code-quality:
     name: Code Quality
@@ -73,8 +76,14 @@ jobs:
       - name: go mod download
         run: go mod download
 
+      - name: Install Dqlite
+        run: |
+          sudo add-apt-repository -y ppa:dqlite/dev 
+          sudo apt install dqlite-tools
+
       - name: Run benchmarks
-        run: make go.bench
+        run: |
+          go test -tags libsqlite3 -v -p 1 ./... -run "^$$" -bench . -benchmem -count $BENCH_COUNT
 
   build:
     name: Build k8s-dqlite

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DQLITE_BUILD_SCRIPTS_DIR ?= $(shell pwd)/hack
 GO_SOURCES = $(shell find . -name '*.go')
+BENCH_COUNT ?= 7
 
 ## Development
 go.fmt:
@@ -13,7 +14,7 @@ go.test:
 	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v -p 1 ./...
 
 go.bench:
-	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v -p 1 ./... -run "^$$" -bench "Benchmark" -benchmem
+	$(DQLITE_BUILD_SCRIPTS_DIR)/static-go-test.sh -v -p 1 ./... -run "^$$" -bench "Benchmark" -benchmem -count $(BENCH_COUNT)
 
 ## Static Builds
 static: bin/static/k8s-dqlite bin/static/dqlite


### PR DESCRIPTION
This PR makes each benchmark run at least 7 times (which in general is the minimum amount of repetitions to compute `p` with `benchstat` tool).

Given that this will increase again bench time, I removed the building of dqlite and used the PPA instead, so that some of the time spent there can be saved.