### PR TITLE
Suppress logrus output during tests

### DIFF
--- a/pkg/kine/drivers/generic_test.go
+++ b/pkg/kine/drivers/generic_test.go
@@ -3,13 +3,20 @@ package drivers_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/logstructured/sqllog"
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
+
+func init() {
+	logrus.SetOutput(io.Discard)
+	logrus.SetLevel(logrus.FatalLevel)
+}
 
 type makeBackendFunc func(ctx context.Context, tb testing.TB) (server.Backend, *generic.Generic, error)
 

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -3,14 +3,21 @@ package test
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
+	"github.com/sirupsen/logrus"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
+
+func init() {
+	logrus.SetOutput(io.Discard)
+	logrus.SetLevel(logrus.FatalLevel)
+}
 
 // newKine spins up a new instance of kine.
 //


### PR DESCRIPTION
Logrus output during tests is flooding the output and making it difficult to properly run `benchstat` on the output. This PR redirects the output to `io.Discard` for that and sets the log level to `Fatal` so that the log footprint is minimal.