### PR TITLE
Instrument SQLite

### DIFF
--- a/pkg/instrument/extension.c
+++ b/pkg/instrument/extension.c
@@ -1,0 +1,77 @@
+#include "extension.h"
+
+#include <sqlite3.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+
+static volatile sqlite3_stats_t global = {0};
+    
+static sqlite3_error collect_profile_stats(unsigned int event, void *pCtx, void *P, void *X) {
+    if (event == SQLITE_TRACE_PROFILE) {
+        sqlite3_stmt* stmt = P;
+        sqlite3* connection = sqlite3_db_handle(stmt);
+
+        int64_t stmt_time_ns = *(sqlite3_int64*)(X);
+        int cache_hit, cache_miss, cache_write, cache_spill, _;
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_HIT, &cache_hit, &_, 1);
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_MISS, &cache_miss, &_, 1);
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_WRITE, &cache_write, &_, 1);
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_SPILL, &cache_spill, &_, 1);
+
+        atomic_fetch_add(&global.pages_cache_hit, cache_hit);
+        atomic_fetch_add(&global.pages_cache_miss, cache_miss);
+        atomic_fetch_add(&global.pages_cache_write, cache_write);
+        atomic_fetch_add(&global.pages_cache_spill, cache_spill);
+
+        if (sqlite3_stmt_readonly(stmt)) {
+            atomic_fetch_add(&global.read_txn_time_ns, stmt_time_ns);
+        } else {
+            atomic_fetch_add(&global.write_txn_time_ns, stmt_time_ns);
+        }
+        
+        return SQLITE_OK;
+    }
+    
+    if (event == SQLITE_TRACE_CLOSE) {
+        sqlite3_trace_v2(P, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, NULL, NULL);
+    }
+    
+    return SQLITE_OK;
+}
+
+sqlite3_error sqlite3_stats(sqlite3_stats_t* stats, int reset) {
+    if (stats == NULL) {
+        return SQLITE_ERROR;
+    }
+
+    if (reset) {
+        stats->pages_cache_write = atomic_exchange(&global.pages_cache_write, 0);
+        stats->pages_cache_hit = atomic_exchange(&global.pages_cache_hit, 0);
+        stats->pages_cache_miss = atomic_exchange(&global.pages_cache_miss, 0);
+        stats->pages_cache_miss = atomic_exchange(&global.pages_cache_spill, 0);
+        stats->read_txn_time_ns = atomic_exchange(&global.read_txn_time_ns, 0);
+        stats->write_txn_time_ns = atomic_exchange(&global.write_txn_time_ns, 0);
+    } else {
+        stats->pages_cache_write = atomic_load(&global.pages_cache_write);
+        stats->pages_cache_hit = atomic_load(&global.pages_cache_hit);
+        stats->pages_cache_miss = atomic_load(&global.pages_cache_miss);
+        stats->pages_cache_miss = atomic_load(&global.pages_cache_spill);
+        stats->read_txn_time_ns = atomic_load(&global.read_txn_time_ns);
+        stats->write_txn_time_ns = atomic_load(&global.write_txn_time_ns);
+    }
+
+    return SQLITE_OK;
+}
+
+static sqlite3_error auto_instrument_connection(sqlite3 *connection, const char** pzErrMsg, const struct sqlite3_api_routines* pThunk) {
+    return sqlite3_trace_v2(connection, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, collect_profile_stats, NULL);
+}
+
+sqlite3_error sqlite3_instrument() {
+    return sqlite3_auto_extension((void (*)())(auto_instrument_connection));
+}
+
+void sqlite3_uninstrument(sqlite3 *connection) {
+    sqlite3_cancel_auto_extension((void (*)())(auto_instrument_connection));
+}

--- a/pkg/instrument/extension.c
+++ b/pkg/instrument/extension.c
@@ -5,64 +5,8 @@
 #include <stdint.h>
 #include <string.h>
 
-static volatile sqlite3_metrics_t global = {0};
+static volatile sqlite3_metrics_t global_metrics = {0};
 
-sqlite3_error sqlite3_collect_metrics(unsigned int event, void *pCtx, void *P, void *X) {
-    if (event == SQLITE_TRACE_PROFILE) {
-        sqlite3_stmt* stmt = P;
-        sqlite3* connection = sqlite3_db_handle(stmt);
-
-        int64_t stmt_time_ns = *(sqlite3_int64*)(X);
-        int cache_hit, cache_miss, cache_write, cache_spill, _;
-        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_HIT, &cache_hit, &_, 1);
-        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_MISS, &cache_miss, &_, 1);
-        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_WRITE, &cache_write, &_, 1);
-        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_SPILL, &cache_spill, &_, 1);
-
-        atomic_fetch_add(&global.pages_cache_hit, cache_hit);
-        atomic_fetch_add(&global.pages_cache_miss, cache_miss);
-        atomic_fetch_add(&global.pages_cache_write, cache_write);
-        atomic_fetch_add(&global.pages_cache_spill, cache_spill);
-
-        if (sqlite3_stmt_readonly(stmt)) {
-            atomic_fetch_add(&global.read_txn_time_ns, stmt_time_ns);
-        } else {
-            atomic_fetch_add(&global.write_txn_time_ns, stmt_time_ns);
-        }
-        
-        return SQLITE_OK;
-    }
-    
-    if (event == SQLITE_TRACE_CLOSE) {
-        sqlite3_trace_v2(P, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, NULL, NULL);
-    }
-    
-    return SQLITE_OK;
-}
-
-sqlite3_error sqlite3_metrics(sqlite3_metrics_t* stats, int reset) {
-    if (stats == NULL) {
-        return SQLITE_ERROR;
-    }
-
-    if (reset) {
-        stats->pages_cache_write = atomic_exchange(&global.pages_cache_write, 0);
-        stats->pages_cache_hit = atomic_exchange(&global.pages_cache_hit, 0);
-        stats->pages_cache_miss = atomic_exchange(&global.pages_cache_miss, 0);
-        stats->pages_cache_miss = atomic_exchange(&global.pages_cache_spill, 0);
-        stats->read_txn_time_ns = atomic_exchange(&global.read_txn_time_ns, 0);
-        stats->write_txn_time_ns = atomic_exchange(&global.write_txn_time_ns, 0);
-    } else {
-        stats->pages_cache_write = atomic_load(&global.pages_cache_write);
-        stats->pages_cache_hit = atomic_load(&global.pages_cache_hit);
-        stats->pages_cache_miss = atomic_load(&global.pages_cache_miss);
-        stats->pages_cache_miss = atomic_load(&global.pages_cache_spill);
-        stats->read_txn_time_ns = atomic_load(&global.read_txn_time_ns);
-        stats->write_txn_time_ns = atomic_load(&global.write_txn_time_ns);
-    }
-
-    return SQLITE_OK;
-}
 
 static sqlite3_error auto_instrument_connection(sqlite3 *connection, const char** pzErrMsg, const struct sqlite3_api_routines* pThunk) {
     return sqlite3_trace_v2(connection, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, sqlite3_collect_metrics, NULL);
@@ -72,6 +16,63 @@ sqlite3_error sqlite3_instrument() {
     return sqlite3_auto_extension((void (*)())(auto_instrument_connection));
 }
 
-void sqlite3_uninstrument() {
+void sqlite3_deinstrument() {
     sqlite3_cancel_auto_extension((void (*)())(auto_instrument_connection));
+}
+
+sqlite3_error sqlite3_metrics(sqlite3_metrics_t* metrics, int reset) {
+    if (reset) {
+        metrics->pages_cache_write = atomic_exchange(&global_metrics.pages_cache_write, 0);
+        metrics->pages_cache_hit = atomic_exchange(&global_metrics.pages_cache_hit, 0);
+        metrics->pages_cache_miss = atomic_exchange(&global_metrics.pages_cache_miss, 0);
+        metrics->pages_cache_miss = atomic_exchange(&global_metrics.pages_cache_spill, 0);
+        metrics->read_txn_time_ns = atomic_exchange(&global_metrics.read_txn_time_ns, 0);
+        metrics->write_txn_time_ns = atomic_exchange(&global_metrics.write_txn_time_ns, 0);
+    } else {
+        metrics->pages_cache_write = atomic_load(&global_metrics.pages_cache_write);
+        metrics->pages_cache_hit = atomic_load(&global_metrics.pages_cache_hit);
+        metrics->pages_cache_miss = atomic_load(&global_metrics.pages_cache_miss);
+        metrics->pages_cache_miss = atomic_load(&global_metrics.pages_cache_spill);
+        metrics->read_txn_time_ns = atomic_load(&global_metrics.read_txn_time_ns);
+        metrics->write_txn_time_ns = atomic_load(&global_metrics.write_txn_time_ns);
+    }
+
+    return SQLITE_OK;
+}
+
+sqlite3_error sqlite3_collect_metrics(unsigned int event, void *pCtx, void *P, void *X) {
+    sqlite3_stmt* stmt;
+    sqlite3* connection;
+
+    int64_t stmt_time_ns;
+    int cache_hit, cache_miss, cache_write, cache_spill, _;
+    
+    switch (event) {
+    case SQLITE_TRACE_PROFILE:
+        stmt = P;
+        connection = sqlite3_db_handle(stmt);
+        stmt_time_ns = *(sqlite3_int64*)(X);
+
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_WRITE, &cache_write, &_, 1);
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_HIT, &cache_hit, &_, 1);
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_MISS, &cache_miss, &_, 1);
+        sqlite3_db_status(connection, SQLITE_DBSTATUS_CACHE_SPILL, &cache_spill, &_, 1);
+
+        atomic_fetch_add(&global_metrics.pages_cache_write, cache_write);
+        atomic_fetch_add(&global_metrics.pages_cache_hit, cache_hit);
+        atomic_fetch_add(&global_metrics.pages_cache_miss, cache_miss);
+        atomic_fetch_add(&global_metrics.pages_cache_spill, cache_spill);
+
+        if (sqlite3_stmt_readonly(stmt)) {
+            atomic_fetch_add(&global_metrics.read_txn_time_ns, stmt_time_ns);
+        } else {
+            atomic_fetch_add(&global_metrics.write_txn_time_ns, stmt_time_ns);
+        }
+        return SQLITE_OK;
+    case SQLITE_TRACE_CLOSE:
+        sqlite3_trace_v2(P, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, NULL, NULL);
+        return SQLITE_OK;
+    default:
+        return SQLITE_OK;
+    }
 }

--- a/pkg/instrument/extension.c
+++ b/pkg/instrument/extension.c
@@ -5,9 +5,9 @@
 #include <stdint.h>
 #include <string.h>
 
-static volatile sqlite3_stats_t global = {0};
-    
-static sqlite3_error collect_profile_stats(unsigned int event, void *pCtx, void *P, void *X) {
+static volatile sqlite3_metrics_t global = {0};
+
+sqlite3_error sqlite3_collect_metrics(unsigned int event, void *pCtx, void *P, void *X) {
     if (event == SQLITE_TRACE_PROFILE) {
         sqlite3_stmt* stmt = P;
         sqlite3* connection = sqlite3_db_handle(stmt);
@@ -40,7 +40,7 @@ static sqlite3_error collect_profile_stats(unsigned int event, void *pCtx, void 
     return SQLITE_OK;
 }
 
-sqlite3_error sqlite3_stats(sqlite3_stats_t* stats, int reset) {
+sqlite3_error sqlite3_metrics(sqlite3_metrics_t* stats, int reset) {
     if (stats == NULL) {
         return SQLITE_ERROR;
     }
@@ -65,13 +65,13 @@ sqlite3_error sqlite3_stats(sqlite3_stats_t* stats, int reset) {
 }
 
 static sqlite3_error auto_instrument_connection(sqlite3 *connection, const char** pzErrMsg, const struct sqlite3_api_routines* pThunk) {
-    return sqlite3_trace_v2(connection, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, collect_profile_stats, NULL);
+    return sqlite3_trace_v2(connection, SQLITE_TRACE_PROFILE|SQLITE_TRACE_CLOSE, sqlite3_collect_metrics, NULL);
 }
 
 sqlite3_error sqlite3_instrument() {
     return sqlite3_auto_extension((void (*)())(auto_instrument_connection));
 }
 
-void sqlite3_uninstrument(sqlite3 *connection) {
+void sqlite3_uninstrument() {
     sqlite3_cancel_auto_extension((void (*)())(auto_instrument_connection));
 }

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -14,7 +14,7 @@ typedef struct sqlite3_metrics_s {
 } sqlite3_metrics_t;
 
 // sqlite3_instrument register an auto extension that 
-// instruments all new connections to collect key sqlite
+// instruments all new connections to collect sqlite
 // performance metrics. Existing connections will not be 
 // affected.
 // This call uses the trace hook to collect data. Replacing

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -3,7 +3,7 @@
 
 typedef int sqlite3_error;
 
-typedef struct sqlite3_stats_s {
+typedef struct sqlite3_metrics_s {
     uint64_t pages_cache_write;
     uint64_t pages_cache_hit;
     uint64_t pages_cache_miss;
@@ -11,15 +11,16 @@ typedef struct sqlite3_stats_s {
 
     uint64_t read_txn_time_ns;
     uint64_t write_txn_time_ns;
-} sqlite3_stats_t;
+} sqlite3_metrics_t;
 
-// sqlite3_instrument instruments the connection represented
-// by the first argument so it can take measurements of key
-// sqlite performance metrics.
-// It will replace both the commit and the trace hook for 
-// the connection. If an error occurs, the connection is 
-// not touched (i.e. neither the trace nor the commit hook
-// are replaced).
+// sqlite3_instrument register an auto extension that 
+// instruments all new connections to collect key sqlite
+// performance metrics. Existing connections will not be 
+// affected. This call uses the trace hook to collect data.
+// Replacing the hook will remove instrumentation for the
+// connection. In this case, it is possible to call 
+// [sqlite3_collect_metrics] to keep the instrumentation
+// active in a custom trace hook.
 sqlite3_error sqlite3_instrument();
 
 // sqlite3_uninstrument remove instrumentation connection
@@ -29,4 +30,12 @@ sqlite3_error sqlite3_instrument();
 // and the instrumentation context is not freed.
 void sqlite3_uninstrument();
 
-sqlite3_error sqlite3_stats(sqlite3_stats_t* stats, int reset);
+// sqlite3_stats reads copies performance metrics into stats.
+// It returns SQLITE_ERROR error if stats is null, SQLITE_OK
+// otherwise.
+// If reset is != 0, it resets each metric to 0.
+sqlite3_error sqlite3_metrics(sqlite3_metrics_t* stats, int reset);
+
+// sqlite3_collect_metrics is a trace hook that collects performance
+// metrics during the SQLITE_TRACE_PROFILE event.
+sqlite3_error sqlite3_collect_metrics(unsigned int event, void *pCtx, void *P, void *X);

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -13,27 +13,26 @@ typedef struct sqlite3_metrics_s {
     uint64_t write_txn_time_ns;
 } sqlite3_metrics_t;
 
-// sqlite3_instrument register an auto extension that 
-// instruments all new connections to collect sqlite
-// performance metrics. Existing connections will not be 
-// affected.
+// sqlite3_instrument registers an auto extension which 
+// instruments all new connections, causing them to collect
+// sqlite performance metrics. Existing connections will will
+// remain unaffected.
+//
 // This call uses the trace hook to collect data. Replacing
 // the hook will remove instrumentation for the connection. 
 // In this case, it is possible to call [sqlite3_collect_metrics]
 // to keep the instrumentation active in a custom trace hook.
 sqlite3_error sqlite3_instrument();
 
-// sqlite3_deinstrument removes instrumentation connection
-// and free the associated context.
-// It will not restore previous commit or trace hook.
-// If an error occurs, the conneciton is left unchanged
-// and the instrumentation context is not freed.
+// sqlite3_deinstrument stops instrumenting new connections.
+// Existing connections are left unchanged.
 void sqlite3_deinstrument();
 
-// sqlite3_metrics copies the current performance metrics into its first argument.
-// If reset is != 0, it resets each metric to 0.
+// sqlite3_metrics copies the current performance metrics into
+// its first argument.
+// If reset is != 0, it resets the metrics.
 sqlite3_error sqlite3_metrics(sqlite3_metrics_t* metrics, int reset);
 
-// sqlite3_collect_metrics is a trace hook that collects performance
-// metrics during the SQLITE_TRACE_PROFILE event.
+// sqlite3_collect_metrics can be called to collect performance
+// metrics during a SQLITE_TRACE_PROFILE event.
 sqlite3_error sqlite3_collect_metrics(unsigned int event, void *pCtx, void *P, void *X);

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -16,25 +16,23 @@ typedef struct sqlite3_metrics_s {
 // sqlite3_instrument register an auto extension that 
 // instruments all new connections to collect key sqlite
 // performance metrics. Existing connections will not be 
-// affected. This call uses the trace hook to collect data.
-// Replacing the hook will remove instrumentation for the
-// connection. In this case, it is possible to call 
-// [sqlite3_collect_metrics] to keep the instrumentation
-// active in a custom trace hook.
+// affected.
+// This call uses the trace hook to collect data. Replacing
+// the hook will remove instrumentation for the connection. 
+// In this case, it is possible to call [sqlite3_collect_metrics]
+// to keep the instrumentation active in a custom trace hook.
 sqlite3_error sqlite3_instrument();
 
-// sqlite3_uninstrument remove instrumentation connection
+// sqlite3_deinstrument removes instrumentation connection
 // and free the associated context.
 // It will not restore previous commit or trace hook.
 // If an error occurs, the conneciton is left unchanged
 // and the instrumentation context is not freed.
-void sqlite3_uninstrument();
+void sqlite3_deinstrument();
 
-// sqlite3_stats reads copies performance metrics into stats.
-// It returns SQLITE_ERROR error if stats is null, SQLITE_OK
-// otherwise.
+// sqlite3_metrics copies the current performance metrics into its first argument.
 // If reset is != 0, it resets each metric to 0.
-sqlite3_error sqlite3_metrics(sqlite3_metrics_t* stats, int reset);
+sqlite3_error sqlite3_metrics(sqlite3_metrics_t* metrics, int reset);
 
 // sqlite3_collect_metrics is a trace hook that collects performance
 // metrics during the SQLITE_TRACE_PROFILE event.

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -18,10 +18,9 @@ typedef struct sqlite3_metrics_s {
 // sqlite performance metrics. Existing connections will will
 // remain unaffected.
 //
-// This call uses the trace hook to collect data. Replacing
-// the hook will remove instrumentation for the connection. 
-// In this case, it is possible to call [sqlite3_collect_metrics]
-// to keep the instrumentation active in a custom trace hook.
+// This call inserts a trace hook to collect metrics. If this
+// would clash with another hook, see the [sqlite3_collect_metrics]
+// function instead.
 sqlite3_error sqlite3_instrument();
 
 // sqlite3_deinstrument stops instrumenting new connections.

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -1,0 +1,32 @@
+#include <sqlite3.h>
+#include <stdint.h>
+
+typedef int sqlite3_error;
+
+typedef struct sqlite3_stats_s {
+    uint64_t pages_cache_write;
+    uint64_t pages_cache_hit;
+    uint64_t pages_cache_miss;
+    uint64_t pages_cache_spill;
+
+    uint64_t read_txn_time_ns;
+    uint64_t write_txn_time_ns;
+} sqlite3_stats_t;
+
+// sqlite3_instrument instruments the connection represented
+// by the first argument so it can take measurements of key
+// sqlite performance metrics.
+// It will replace both the commit and the trace hook for 
+// the connection. If an error occurs, the connection is 
+// not touched (i.e. neither the trace nor the commit hook
+// are replaced).
+sqlite3_error sqlite3_instrument();
+
+// sqlite3_uninstrument remove instrumentation connection
+// and free the associated context.
+// It will not restore previous commit or trace hook.
+// If an error occurs, the conneciton is left unchanged
+// and the instrumentation context is not freed.
+void sqlite3_uninstrument();
+
+sqlite3_error sqlite3_stats(sqlite3_stats_t* stats, int reset);

--- a/pkg/instrument/extension.h
+++ b/pkg/instrument/extension.h
@@ -4,10 +4,10 @@
 typedef int sqlite3_error;
 
 typedef struct sqlite3_metrics_s {
-    uint64_t pages_cache_write;
-    uint64_t pages_cache_hit;
-    uint64_t pages_cache_miss;
-    uint64_t pages_cache_spill;
+    uint64_t page_cache_writes;
+    uint64_t page_cache_hits;
+    uint64_t page_cache_misses;
+    uint64_t page_cache_spills;
 
     uint64_t read_txn_time_ns;
     uint64_t write_txn_time_ns;
@@ -15,7 +15,7 @@ typedef struct sqlite3_metrics_s {
 
 // sqlite3_instrument registers an auto extension which 
 // instruments all new connections, causing them to collect
-// sqlite performance metrics. Existing connections will will
+// sqlite performance metrics. Existing connections will
 // remain unaffected.
 //
 // This call inserts a trace hook to collect metrics. If this

--- a/pkg/instrument/sqlite.go
+++ b/pkg/instrument/sqlite.go
@@ -12,7 +12,7 @@ import (
 import "C"
 
 // StartSQLiteMonitoring instruments sqlite to collect metrics
-// on all connection opened after the call (i.e. existing connections
+// on all subsequent connections (i.e. existing connections
 // will not be instrumented).
 // Monitoring must be stopped by calling [StopSQLiteMonitoring].
 func StartSQLiteMonitoring() error {
@@ -23,8 +23,7 @@ func StartSQLiteMonitoring() error {
 }
 
 // StopSQLiteMonitoring removes instrumentation from sqlite.
-// Existing connections will still be insturmented until they
-// are closed.
+// After this call, no new connections are instrumented.
 func StopSQLiteMonitoring() { C.sqlite3_deinstrument() }
 
 type SQLiteMetrics struct {

--- a/pkg/instrument/sqlite.go
+++ b/pkg/instrument/sqlite.go
@@ -1,0 +1,50 @@
+package instrument
+
+import (
+	"time"
+	_ "unsafe"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// #cgo LDFLAGS: -lsqlite3
+// #include "extension.h"
+import "C"
+
+func SQLite() (*SQLiteMonitor, error) {
+	if err := C.sqlite3_instrument(); err != sqlite3.SQLITE_OK {
+		return nil, sqlite3.ErrNo(err)
+	}
+
+	return &SQLiteMonitor{}, nil
+}
+
+type SQLiteMonitor struct{}
+
+func (m *SQLiteMonitor) Fetch() *SQLiteStats { return fetchSQLiteStats(0) }
+func (m *SQLiteMonitor) Reset() *SQLiteStats { return fetchSQLiteStats(1) }
+func (m *SQLiteMonitor) Done()               { C.sqlite3_uninstrument() }
+
+type SQLiteStats struct {
+	PagesCacheWrite uint64
+	PagesCacheHit   uint64
+	PagesCacheMiss  uint64
+	PagesCacheSpill uint64
+
+	ReadTransactionTime  time.Duration
+	WriteTransactionTime time.Duration
+}
+
+func fetchSQLiteStats(reset C.int) *SQLiteStats {
+	var cstats C.sqlite3_stats_t
+	C.sqlite3_stats(&cstats, reset)
+
+	return &SQLiteStats{
+		PagesCacheWrite:      uint64(cstats.pages_cache_write),
+		PagesCacheHit:        uint64(cstats.pages_cache_hit),
+		PagesCacheMiss:       uint64(cstats.pages_cache_miss),
+		PagesCacheSpill:      uint64(cstats.pages_cache_spill),
+		ReadTransactionTime:  time.Duration(cstats.read_txn_time_ns) * time.Nanosecond,
+		WriteTransactionTime: time.Duration(cstats.write_txn_time_ns) * time.Nanosecond,
+	}
+}

--- a/pkg/instrument/sqlite.go
+++ b/pkg/instrument/sqlite.go
@@ -29,10 +29,10 @@ func StopSQLiteMonitoring() { C.sqlite3_deinstrument() }
 type SQLiteMetrics struct {
 	// These fields follow the same order as the `struct sqlite3_metrics_s`.
 
-	PagesCacheWrite uint64
-	PagesCacheHit   uint64
-	PagesCacheMiss  uint64
-	PagesCacheSpill uint64
+	PageCacheWrites uint64
+	PageCacheHits   uint64
+	PageCacheMisses uint64
+	PageCacheSpills uint64
 
 	TransactionReadTime  time.Duration
 	TransactionWriteTime time.Duration
@@ -57,10 +57,10 @@ func FetchSQLiteMetrics() *SQLiteMetrics {
 
 func convertMetrics(stats *C.sqlite3_metrics_t) *SQLiteMetrics {
 	return &SQLiteMetrics{
-		PagesCacheWrite:      uint64(stats.pages_cache_write),
-		PagesCacheHit:        uint64(stats.pages_cache_hit),
-		PagesCacheMiss:       uint64(stats.pages_cache_miss),
-		PagesCacheSpill:      uint64(stats.pages_cache_spill),
+		PageCacheWrites:      uint64(stats.page_cache_writes),
+		PageCacheHits:        uint64(stats.page_cache_hits),
+		PageCacheMisses:      uint64(stats.page_cache_misses),
+		PageCacheSpills:      uint64(stats.page_cache_spills),
 		TransactionReadTime:  time.Duration(stats.read_txn_time_ns) * time.Nanosecond,
 		TransactionWriteTime: time.Duration(stats.write_txn_time_ns) * time.Nanosecond,
 	}

--- a/test/admission_test.go
+++ b/test/admission_test.go
@@ -25,7 +25,7 @@ func TestAdmissionControl(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{
+			kine := newKineServer(ctx, t, &kineOptions{
 				backendType: backendType,
 				endpointParameters: []string{
 					"admission-control-policy=limit",

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -90,10 +90,12 @@ func BenchmarkCompaction(b *testing.B) {
 				},
 			})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			if err := kine.backend.DoCompact(ctx); err != nil {
 				b.Fatal(err)
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -19,7 +19,7 @@ func TestCompaction(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				kine := newKine(ctx, t, &kineOptions{
+				kine := newKineServer(ctx, t, &kineOptions{
 					backendType: backendType,
 					setup: func(db *sql.DB) error {
 						return setupScenario(ctx, db, "testkey", 2, 1, 1)
@@ -45,7 +45,7 @@ func TestCompaction(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				kine := newKine(ctx, t, &kineOptions{
+				kine := newKineServer(ctx, t, &kineOptions{
 					backendType: backendType,
 					setup: func(db *sql.DB) error {
 						return setupScenario(ctx, db, "testkey", 10_000, 500, 500)
@@ -75,14 +75,14 @@ func BenchmarkCompaction(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{
+			kine := newKineServer(ctx, b, &kineOptions{
 				backendType: backendType,
 				setup: func(db *sql.DB) error {
-					// Make sure there's enough rows deleted to have
+					// Make sure there are enough rows deleted to have
 					// b.N rows to compact.
 					delCount := b.N + sqllog.SupersededCount
 
-					// Also, make sure there's some uncollectable data, so
+					// Also, make sure there are uncollectable data, so
 					// that the deleted rows are about 5% of the total.
 					addCount := delCount * 20
 

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -46,12 +46,14 @@ func BenchmarkCreate(b *testing.B) {
 
 			kine := newKine(ctx, b, &kineOptions{backendType: backendType})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				key := fmt.Sprintf("key-%d", i)
 				value := fmt.Sprintf("value-%d", i)
 				createKey(ctx, g, kine.client, key, value)
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -19,7 +19,7 @@ func TestCreate(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			createKey(ctx, g, kine.client, "testKey", "testValue")
 
@@ -44,7 +44,7 @@ func BenchmarkCreate(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
 
 			kine.ResetMetrics()
 			b.StartTimer()

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -71,11 +71,13 @@ func BenchmarkDelete(b *testing.B) {
 				},
 			})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				key := fmt.Sprintf("key/%d", i)
 				deleteKey(ctx, g, kine.client, key)
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -18,7 +18,7 @@ func TestDelete(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			// Calling the delete method outside a transaction should fail in kine
 			t.Run("DeleteNotSupportedFails", func(t *testing.T) {
@@ -64,7 +64,7 @@ func BenchmarkDelete(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{
+			kine := newKineServer(ctx, b, &kineOptions{
 				backendType: backendType,
 				setup: func(db *sql.DB) error {
 					return setupScenario(ctx, db, "key", b.N, 0, 0)

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -18,7 +18,7 @@ func TestGet(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			t.Run("FailNotFound", func(t *testing.T) {
 				g := NewWithT(t)
@@ -122,7 +122,7 @@ func BenchmarkGet(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{
+			kine := newKineServer(ctx, b, &kineOptions{
 				backendType: backendType,
 				setup: func(db *sql.DB) error {
 					return setupScenario(ctx, db, "testKey", b.N, b.N, 0)

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -129,12 +129,14 @@ func BenchmarkGet(b *testing.B) {
 				},
 			})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				resp, err := kine.client.Get(ctx, fmt.Sprintf("testKey/%d", i+1), clientv3.WithRange(""))
 				g.Expect(err).To(BeNil())
 				g.Expect(resp.Kvs).To(HaveLen(1))
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -92,6 +92,7 @@ func BenchmarkLease(b *testing.B) {
 
 			kine := newKine(ctx, b, &kineOptions{backendType: backendType})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				var ttl int64 = int64(i + 1)
@@ -101,6 +102,7 @@ func BenchmarkLease(b *testing.B) {
 				g.Expect(resp.ID).To(Equal(clientv3.LeaseID(ttl)))
 				g.Expect(resp.TTL).To(Equal(ttl))
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -23,7 +23,7 @@ func TestLease(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			t.Run("LeaseGrant", func(t *testing.T) {
 				g := NewWithT(t)
@@ -90,7 +90,7 @@ func BenchmarkLease(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
 
 			kine.ResetMetrics()
 			b.StartTimer()

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -20,7 +20,7 @@ func TestList(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			keys := []string{"/key/5", "/key/4", "/key/3", "/key/2", "/key/1"}
 			for _, key := range keys {
@@ -188,7 +188,7 @@ func BenchmarkList(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{
+			kine := newKineServer(ctx, b, &kineOptions{
 				backendType: backendType,
 				setup: func(db *sql.DB) error {
 					return setupScenario(ctx, db, "key", b.N*2, b.N, b.N)

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -195,6 +195,7 @@ func BenchmarkList(b *testing.B) {
 				},
 			})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				resp, err := kine.client.Get(ctx, "key/", clientv3.WithPrefix())
@@ -202,6 +203,7 @@ func BenchmarkList(b *testing.B) {
 				g.Expect(err).To(BeNil())
 				g.Expect(resp.Kvs).To(HaveLen(b.N))
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -81,11 +81,13 @@ func BenchmarkUpdate(b *testing.B) {
 
 			kine := newKine(ctx, b, &kineOptions{backendType: backendType})
 
+			kine.ResetMetrics()
 			b.StartTimer()
 			for i, lastModRev := 0, int64(0); i < b.N; i++ {
 				value := fmt.Sprintf("value-%d", i)
 				lastModRev = updateRev(ctx, g, kine.client, "benchKey", lastModRev, value)
 			}
+			kine.ReportMetrics(b)
 		})
 	}
 }

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -17,7 +17,7 @@ func TestUpdate(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			// Testing that update can create a new key if ModRevision is 0
 			t.Run("UpdateNewKey", func(t *testing.T) {
@@ -79,7 +79,7 @@ func BenchmarkUpdate(b *testing.B) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, b, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
 
 			kine.ResetMetrics()
 			b.StartTimer()

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -146,12 +146,12 @@ func startDqlite(ctx context.Context, tb testing.TB, dir string) (*endpoint.Conf
 
 func (ks *kineServer) ReportMetrics(b *testing.B) {
 	sqliteMetrics := instrument.FetchSQLiteMetrics()
-	b.ReportMetric(float64(sqliteMetrics.PagesCacheHit+sqliteMetrics.PagesCacheMiss)/float64(b.N), "pages-read/op")
-	b.ReportMetric(float64(sqliteMetrics.PagesCacheMiss)/float64(b.N), "cache-misses/op")
-	b.ReportMetric(float64(sqliteMetrics.PagesCacheSpill)/float64(b.N), "cache-spill/op")
-	b.ReportMetric(float64(sqliteMetrics.PagesCacheWrite)/float64(b.N), "pages-written/op")
-	b.ReportMetric(float64(sqliteMetrics.TransactionReadTime)/float64(time.Second)/float64(b.N), "sec-read-query/op")
-	b.ReportMetric(float64(sqliteMetrics.TransactionWriteTime)/float64(time.Second)/float64(b.N), "sec-write-query/op")
+	b.ReportMetric(float64(sqliteMetrics.PageCacheHits+sqliteMetrics.PageCacheMisses)/float64(b.N), "page-reads/op")
+	b.ReportMetric(float64(sqliteMetrics.PageCacheMisses)/float64(b.N), "page-cache-misses/op")
+	b.ReportMetric(float64(sqliteMetrics.PageCacheSpills)/float64(b.N), "page-cache-spills/op")
+	b.ReportMetric(float64(sqliteMetrics.PageCacheWrites)/float64(b.N), "page-writes/op")
+	b.ReportMetric(float64(sqliteMetrics.TransactionReadTime)/float64(time.Second)/float64(b.N), "sec-reading/op")
+	b.ReportMetric(float64(sqliteMetrics.TransactionWriteTime)/float64(time.Second)/float64(b.N), "sec-writing/op")
 }
 
 func (ks *kineServer) ResetMetrics() {

--- a/test/watch_test.go
+++ b/test/watch_test.go
@@ -35,7 +35,7 @@ func TestWatch(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			kine := newKine(ctx, t, &kineOptions{backendType: backendType})
+			kine := newKineServer(ctx, t, &kineOptions{backendType: backendType})
 
 			// start watching for events on key
 			watchCh := kine.client.Watch(ctx, key)


### PR DESCRIPTION
This PR enables monitoring SQLite performance metrics. In detail, it adds the following metrics:

 - pages written
   - cache spill (when the write cache needs to be unloaded as the transaction is too big)
 - pages read
   - read cache hits
 - time spent in a read transaction
 - time spent in a write transaction

These will be useful to understand how a new query impacts the database.