### PR TITLE
Improve compaction

### DIFF
--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -25,7 +25,7 @@ const otelName = "generic"
 var (
 	otelTracer       trace.Tracer
 	otelMeter        metric.Meter
-	setCompactRevCnt metric.Int64Counter
+	compactCnt       metric.Int64Counter
 	getRevisionCnt   metric.Int64Counter
 	deleteRevCnt     metric.Int64Counter
 	currentRevCnt    metric.Int64Counter
@@ -36,7 +36,7 @@ func init() {
 	var err error
 	otelTracer = otel.Tracer(otelName)
 	otelMeter = otel.Meter(otelName)
-	setCompactRevCnt, err = otelMeter.Int64Counter(fmt.Sprintf("%s.compact", otelName), metric.WithDescription("Number of compact requests"))
+	compactCnt, err = otelMeter.Int64Counter(fmt.Sprintf("%s.compact", otelName), metric.WithDescription("Number of compact requests"))
 	if err != nil {
 		logrus.WithError(err).Warning("Otel failed to create create counter")
 	}
@@ -103,16 +103,12 @@ var (
 
 	revisionIntervalSQL = `
 		SELECT (
-			SELECT crkv.prev_revision
-			FROM kine AS crkv
-			WHERE crkv.name = 'compact_rev_key'
-			ORDER BY prev_revision
-			DESC LIMIT 1
-		) AS low, (
-			SELECT id
+			SELECT MAX(prev_revision)
 			FROM kine
-			ORDER BY id
-			DESC LIMIT 1
+			WHERE name = 'compact_rev_key'
+		) AS low, (
+			SELECT MAX(id)
+			FROM kine
 		) AS high`
 )
 
@@ -145,6 +141,7 @@ type Generic struct {
 	AfterSQLPrefix        string
 	AfterSQL              string
 	DeleteSQL             string
+	CompactSQL            string
 	UpdateCompactSQL      string
 	InsertSQL             string
 	FillSQL               string
@@ -268,7 +265,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, paramCharacter
 
 		UpdateCompactSQL: q(`
 			UPDATE kine
-			SET prev_revision = ?
+			SET prev_revision = max(prev_revision, ?)
 			WHERE name = 'compact_rev_key'`, paramCharacter, numbered),
 
 		InsertLastInsertIDSQL: q(`INSERT INTO kine(name, created, deleted, create_revision, prev_revision, lease, value, old_value)
@@ -479,6 +476,87 @@ func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int6
 	return result.LastInsertId()
 }
 
+// Compact compacts to revision the database. After the call,
+// any request for a version older than revision will return
+// a compacted error.
+func (d *Generic) Compact(ctx context.Context, revision int64) (err error) {
+	compactCnt.Add(ctx, 1)
+	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.compact", otelName))
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+	compactStart, currentRevision, err := d.GetCompactRevision(ctx)
+	if err != nil {
+		return err
+	}
+	if compactStart >= revision {
+		return nil // Nothing to compact.
+	}
+	if revision > currentRevision {
+		revision = currentRevision
+	}
+
+	for retryCount := 0; retryCount < maxRetries; retryCount++ {
+		err = d.tryCompact(ctx, compactStart, revision)
+		if err == nil || d.Retry == nil || !d.Retry(err) {
+			break
+		}
+	}
+	return err
+}
+
+func (d *Generic) tryCompact(ctx context.Context, start, end int64) error {
+	tx, err := d.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			logrus.WithError(err).Trace("can't rollback compaction")
+		}
+	}()
+
+	// This query adds `created = 0` as a condition
+	// to mitigate a bug in vXXX where newly created
+	// keys had `prev_revision = max(id)` instead of 0.
+	// Even with the bug fixed, we still need to check
+	// for that in older rows and if older peers are
+	// still running. Given that we are not yet using
+	// an index, it won't change much in performance
+	// however, it should be included in a covering
+	// index if ever necessary.
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM kine
+		WHERE id IN (
+			SELECT prev_revision
+			FROM kine
+			WHERE name != 'compact_rev_key'
+				AND created = 0
+				AND prev_revision != 0
+				AND ? < id AND id <= ?
+		)
+	`, start, end)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM kine
+		WHERE deleted = 1
+			AND ? < id AND id <= ?
+	`, start, end)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, d.UpdateCompactSQL, end)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) {
 	getCompactRevCnt.Add(ctx, 1)
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.get_compact_revision", otelName))
@@ -486,9 +564,6 @@ func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) 
 	start := time.Now()
 	var err error
 	defer func() {
-		if err == sql.ErrNoRows {
-			err = nil
-		}
 		span.RecordError(err)
 		recordOpResult("revision_interval_sql", err, start)
 		recordTxResult("revision_interval_sql", err)
@@ -511,7 +586,7 @@ func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) 
 		if err := rows.Err(); err != nil {
 			return 0, 0, err
 		}
-		return 0, 0, nil
+		return 0, 0, fmt.Errorf("cannot get compact revision: aggregate query returned no rows")
 	}
 
 	if err := rows.Scan(&compact, &target); err != nil {
@@ -519,20 +594,6 @@ func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) 
 	}
 	span.SetAttributes(attribute.Int64("compact", compact.Int64), attribute.Int64("target", target.Int64))
 	return compact.Int64, target.Int64, err
-}
-
-func (d *Generic) SetCompactRevision(ctx context.Context, revision int64) error {
-	var err error
-	setCompactRevCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.set_compact_revision", otelName))
-	defer func() {
-		span.End()
-		span.RecordError(err)
-	}()
-	span.SetAttributes(attribute.Int64("revision", revision))
-
-	_, err = d.execute(ctx, "update_compact_sql", d.UpdateCompactSQL, revision)
-	return err
 }
 
 func (d *Generic) GetRevision(ctx context.Context, revision int64) (*sql.Rows, error) {

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -145,18 +145,6 @@ func (s *SQLLog) DoCompact(ctx context.Context) error {
 		return fmt.Errorf("failed to initialise compaction: %v", err)
 	}
 
-	// NOTE: Upstream is ignoring the last 1000 revisions, however that causes the following CNCF conformance test to fail.
-	// This is because of low activity, where the created list is part of the last 1000 revisions and is not compacted.
-	// Link to failing test: https://github.com/kubernetes/kubernetes/blob/f2cfbf44b1fb482671aedbfff820ae2af256a389/test/e2e/apimachinery/chunking.go#L144
-	// To address this, we only ignore the last 100 revisions instead
-	rev, err := s.d.CurrentRevision(ctx)
-	if err != nil {
-		return err
-	}
-	return s.d.Compact(ctx, rev-SupersededCount)
-}
-
-func (s *SQLLog) compact(ctx context.Context) error {
 	// When executing compaction as a background operation
 	// it's best not to take too much time away from query
 	// operation and similar. As such, we do compaction in
@@ -167,8 +155,16 @@ func (s *SQLLog) compact(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// NOTE: Upstream is ignoring the last 1000 revisions, however that causes the following CNCF conformance test to fail.
+	// This is because of low activity, where the created list is part of the last 1000 revisions and is not compacted.
+	// Link to failing test: https://github.com/kubernetes/kubernetes/blob/f2cfbf44b1fb482671aedbfff820ae2af256a389/test/e2e/apimachinery/chunking.go#L144
+	// To address this, we only ignore the last 100 revisions instead
+	target -= SupersededCount
 	for start < target {
 		batchRevision := start + compactBatchSize
+		if batchRevision > target {
+			batchRevision = target
+		}
 		if err := s.d.Compact(s.ctx, batchRevision); err != nil {
 			return err
 		}
@@ -354,7 +350,7 @@ func (s *SQLLog) startWatch() (chan interface{}, error) {
 			case <-s.ctx.Done():
 				return
 			case <-t.C:
-				if err := s.compact(s.ctx); err != nil {
+				if err := s.DoCompact(s.ctx); err != nil {
 					logrus.WithError(err).Trace("compaction failed")
 				}
 			}

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	SupersededCount = 100
-	otelName        = "sqllog"
+	SupersededCount  = 100
+	compactBatchSize = 1000
+	otelName         = "sqllog"
 )
 
 var (
@@ -68,7 +69,7 @@ type Dialect interface {
 	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
 	DeleteRevision(ctx context.Context, revision int64) error
 	GetCompactRevision(ctx context.Context) (int64, int64, error)
-	SetCompactRevision(ctx context.Context, revision int64) error
+	Compact(ctx context.Context, revision int64) error
 	Fill(ctx context.Context, revision int64) error
 	IsFill(key string) bool
 	GetSize(ctx context.Context) (int64, error)
@@ -144,133 +145,36 @@ func (s *SQLLog) DoCompact(ctx context.Context) error {
 		return fmt.Errorf("failed to initialise compaction: %v", err)
 	}
 
-	nextEnd, _ := s.d.CurrentRevision(ctx)
-	_, err := s.compactor(ctx, nextEnd)
-
-	return err
-}
-
-func (s *SQLLog) compactor(ctx context.Context, nextEnd int64) (int64, error) {
-	var err error
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.compactor", otelName))
-	defer func() {
-		span.RecordError(err)
-		span.End()
-	}()
-	span.SetAttributes(attribute.Int64("nextEnd", nextEnd))
-
-	currentRev, err := s.d.CurrentRevision(ctx)
-	span.SetAttributes(attribute.Int64("currentRev", currentRev))
-	if err != nil {
-		logrus.Errorf("failed to get current revision: %v", err)
-		return nextEnd, fmt.Errorf("failed to get current revision: %v", err)
-	}
-
-	cursor, _, err := s.d.GetCompactRevision(ctx)
-	if err != nil {
-		logrus.Errorf("failed to get compact revision: %v", err)
-		return nextEnd, fmt.Errorf("failed to get compact revision: %v", err)
-	}
-	span.SetAttributes(attribute.Int64("cursor", cursor))
-
-	end := nextEnd
-	nextEnd = currentRev
-
-	// NOTE(neoaggelos): Ignoring the last 1000 revisions causes the following CNCF conformance test to fail.
+	// NOTE: Upstream is ignoring the last 1000 revisions, however that causes the following CNCF conformance test to fail.
 	// This is because of low activity, where the created list is part of the last 1000 revisions and is not compacted.
 	// Link to failing test: https://github.com/kubernetes/kubernetes/blob/f2cfbf44b1fb482671aedbfff820ae2af256a389/test/e2e/apimachinery/chunking.go#L144
 	// To address this, we only ignore the last 100 revisions instead
-	end = end - SupersededCount
-
-	savedCursor := cursor
-	// Purposefully start at the current and redo the current as
-	// it could have failed before actually compacting
-	compactCnt.Add(ctx, 1)
-	span.AddEvent(fmt.Sprintf("start compaction from %d to %d", cursor, end))
-	for ; cursor <= end; cursor++ {
-		rows, err := s.d.GetRevision(ctx, cursor)
-		if err != nil {
-			logrus.Errorf("failed to get revision %d: %v", cursor, err)
-			return nextEnd, fmt.Errorf("failed to get revision %d: %v", cursor, err)
-		}
-
-		events, err := RowsToEvents(rows)
-		if err != nil {
-			logrus.Errorf("failed to convert to events: %v", err)
-			return nextEnd, fmt.Errorf("failed to convert to events: %v", err)
-		}
-
-		if len(events) == 0 {
-			continue
-		}
-
-		event := events[0]
-
-		if event.KV.Key == "compact_rev_key" {
-			span.AddEvent("skip compact_rev_key")
-			// don't compact the compact key
-			continue
-		}
-
-		setRev := false
-		if event.PrevKV != nil && event.PrevKV.ModRevision != 0 {
-			if savedCursor != cursor {
-				if err := s.d.SetCompactRevision(ctx, cursor); err != nil {
-					span.AddEvent(fmt.Sprintf("failed to record compact revision: %v", err))
-					logrus.Errorf("failed to record compact revision: %v", err)
-					return nextEnd, fmt.Errorf("failed to record compact revision: %v", err)
-				}
-				savedCursor = cursor
-				setRev = true
-			}
-
-			if err := s.d.DeleteRevision(ctx, event.PrevKV.ModRevision); err != nil {
-				span.AddEvent(fmt.Sprintf("failed to delete revision %d", event.PrevKV.ModRevision))
-				logrus.Errorf("failed to delete revision %d: %v", event.PrevKV.ModRevision, err)
-				return nextEnd, fmt.Errorf("failed to delete revision %d: %v", event.PrevKV.ModRevision, err)
-			}
-		}
-
-		if event.Delete {
-			if !setRev && savedCursor != cursor {
-				if err := s.d.SetCompactRevision(ctx, cursor); err != nil {
-					logrus.Errorf("failed to record compact revision: %v", err)
-					return nextEnd, fmt.Errorf("failed to record compact revision: %v", err)
-				}
-				savedCursor = cursor
-			}
-
-			if err := s.d.DeleteRevision(ctx, cursor); err != nil {
-				logrus.Errorf("failed to delete current revision %d: %v", cursor, err)
-				return nextEnd, fmt.Errorf("failed to delete current revision %d: %v", cursor, err)
-			}
-		}
+	rev, err := s.d.CurrentRevision(ctx)
+	if err != nil {
+		return err
 	}
-
-	if savedCursor != cursor {
-		if err := s.d.SetCompactRevision(ctx, cursor); err != nil {
-			logrus.Errorf("failed to record compact revision: %v", err)
-			return nextEnd, fmt.Errorf("failed to record compact revision: %v", err)
-		}
-	}
-	span.SetAttributes(attribute.Int64("new-nextEnd", nextEnd), attribute.Int64("cursor-ended:", cursor))
-	return nextEnd, nil
+	return s.d.Compact(ctx, rev-SupersededCount)
 }
 
-func (s *SQLLog) compact() {
-	var nextEnd int64
-	t := time.NewTicker(s.d.GetCompactInterval())
-	nextEnd, _ = s.d.CurrentRevision(s.ctx)
-
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
-		case <-t.C:
-		}
-
-		nextEnd, _ = s.compactor(s.ctx, nextEnd)
+func (s *SQLLog) compact(ctx context.Context) error {
+	// When executing compaction as a background operation
+	// it's best not to take too much time away from query
+	// operation and similar. As such, we do compaction in
+	// small batches. Given that this logic runs every second,
+	// on regime it should take usually just a couple batches
+	// to keep the pace.
+	start, target, err := s.d.GetCompactRevision(ctx)
+	if err != nil {
+		return err
 	}
+	for start < target {
+		batchRevision := start + compactBatchSize
+		if err := s.d.Compact(s.ctx, batchRevision); err != nil {
+			return err
+		}
+		start = batchRevision
+	}
+	return nil
 }
 
 func (s *SQLLog) CurrentRevision(ctx context.Context) (int64, error) {
@@ -442,7 +346,19 @@ func (s *SQLLog) startWatch() (chan interface{}, error) {
 
 	go func() {
 		defer s.wg.Done()
-		s.compact()
+
+		t := time.NewTicker(s.d.GetCompactInterval())
+
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-t.C:
+				if err := s.compact(s.ctx); err != nil {
+					logrus.WithError(err).Trace("compaction failed")
+				}
+			}
+		}
 	}()
 
 	go func() {

--- a/pkg/kine/prepared/db.go
+++ b/pkg/kine/prepared/db.go
@@ -23,19 +23,19 @@ func New(db *sql.DB) *DB {
 func (db *DB) Underlying() *sql.DB { return db.underlying }
 
 func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	stms, err := db.prepare(ctx, query)
+	stmt, err := db.prepare(ctx, query)
 	if err != nil {
 		return nil, err
 	}
-	return stms.ExecContext(ctx, args...)
+	return stmt.ExecContext(ctx, args...)
 }
 
 func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	stms, err := db.prepare(ctx, query)
+	stmt, err := db.prepare(ctx, query)
 	if err != nil {
 		return nil, err
 	}
-	return stms.QueryContext(ctx, args...)
+	return stmt.QueryContext(ctx, args...)
 }
 
 func (db *DB) Close() error {
@@ -86,4 +86,16 @@ func (db *DB) prepare(ctx context.Context, query string) (*sql.Stmt, error) {
 
 	db.store[query] = prepared
 	return prepared, nil
+}
+
+func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
+	tx, err := db.underlying.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Tx{
+		db: db,
+		tx: tx,
+	}, nil
 }

--- a/pkg/kine/prepared/tx.go
+++ b/pkg/kine/prepared/tx.go
@@ -1,0 +1,32 @@
+package prepared
+
+import (
+	"context"
+	"database/sql"
+)
+
+type Tx struct {
+	db *DB
+	tx *sql.Tx
+}
+
+func (tx *Tx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	stmt, err := tx.db.prepare(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx.tx.StmtContext(ctx, stmt).ExecContext(ctx, args...)
+}
+
+func (tx *Tx) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	stmt, err := tx.db.prepare(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx.tx.StmtContext(ctx, stmt).QueryContext(ctx, args...)
+}
+
+func (tx *Tx) Commit() error   { return tx.tx.Commit() }
+func (tx *Tx) Rollback() error { return tx.tx.Rollback() }

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -98,7 +98,6 @@ func BenchmarkCompaction(b *testing.B) {
 			b.StopTimer()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-
 			kine := newKineServer(ctx, b, &kineOptions{
 				backendType: backendType,
 				setup: func(ctx context.Context, tx *sql.Tx) error {
@@ -119,7 +118,6 @@ func BenchmarkCompaction(b *testing.B) {
 					return nil
 				},
 			})
-
 			kine.ResetMetrics()
 			b.StartTimer()
 			if err := kine.backend.DoCompact(ctx); err != nil {

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -114,6 +114,9 @@ func newKineServer(ctx context.Context, tb testing.TB, options *kineOptions) *ki
 		DialTimeout: 5 * time.Second,
 		TLS:         tlsConfig,
 	})
+	tb.Cleanup(func() {
+		client.Close()
+	})
 	if err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
## Description
This PR rewrites the compaction step in a similar way [upstream](https://github.com/k3s-io/kine/pull/51) is doing. This way, the throughput should be a lot higher. The main differences from upstream are:
 - small batches instead of a single big one;
 - proper range boundaries to reduce search space;
 - in-transaction update of the compaction version.

This query does not use indexes right now. It's still *way faster* than what we have and what upstream has. Maybe we could improve things with a covering index if/when it's needed for the Watch/TTL query. Otherwise we might be ok with what we have.

## Improvements to the previous implementation
Up to this point we've been doing compaction on each revision within the compaction range row by row. Looping over all revisions takes about 7s on an idle cluster, rare issues have been recorded where compaction takes minutes. With this compaction query improvement we are doing a compaction batch in around 40ms and a max <100ms on an idle cluster. (Note: the idle cluster only needs 1 batch to complete the compaction under normal circumstances).

This PR addresses: https://github.com/canonical/k8s-dqlite/issues/145 and https://github.com/canonical/k8s-dqlite/issues/146