### PR TITLE
Address concurrency issue in logstructured.create

### DIFF
--- a/pkg/kine/logstructured/logstructured.go
+++ b/pkg/kine/logstructured/logstructured.go
@@ -151,7 +151,7 @@ func (l *LogStructured) Create(ctx context.Context, key string, value []byte, le
 
 	}()
 
-	rev, prevEvent, err := l.get(ctx, key, "", 1, 0, true)
+	_, prevEvent, err := l.get(ctx, key, "", 1, 0, true)
 	if err != nil {
 		return 0, err
 	}
@@ -163,7 +163,7 @@ func (l *LogStructured) Create(ctx context.Context, key string, value []byte, le
 			Lease: lease,
 		},
 		PrevKV: &server.KeyValue{
-			ModRevision: rev,
+			ModRevision: 0,
 		},
 	}
 	if prevEvent != nil {


### PR DESCRIPTION
## Description
At the moment `logstructured.create` is not a single transaction (which is the plan for future work).
There is a rare concurrency issue resulting as a result of a lack of error handling and a bug in the code. The quick fix here is to set the previous revision of the newly created entry to zero always as a new entry does not have a previous revision to refer to in the first place.
We can run into troubles as `rev` is not zero when passed (which leads to pointing to a wrong previous revision, it doesn't have any), and changes when another entry gets inserted in the meantime. In rare circumstances we could end up with two insert of the same key with different previous revisions.