### PR TITLE
Improve create query

### DIFF
--- a/pkg/kine/drivers/generic/admission.go
+++ b/pkg/kine/drivers/generic/admission.go
@@ -31,6 +31,7 @@ var writeQueries = map[string]bool{
 	"fill_sql":                  true,
 	"insert_last_insert_id_sql": true,
 	"insert_sql":                true,
+	"create_sql":                true,
 }
 
 // allowAllPolicy always admits queries.

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -449,7 +449,7 @@ func (d *Generic) Count(ctx context.Context, prefix, startKey string, revision i
 }
 
 func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int64) (rev int64, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.create", otelName))
+	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -458,7 +458,6 @@ func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int6
 	span.SetAttributes(
 		attribute.String("key", key),
 		attribute.Int64("ttl", ttl),
-		attribute.String("value", string(value)),
 	)
 	defer func() {
 		if err != nil {

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -450,15 +450,7 @@ func (d *Generic) Count(ctx context.Context, prefix, startKey string, revision i
 
 func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int64) (rev int64, err error) {
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
-	defer func() {
-		span.RecordError(err)
-		span.End()
-	}()
 
-	span.SetAttributes(
-		attribute.String("key", key),
-		attribute.Int64("ttl", ttl),
-	)
 	defer func() {
 		if err != nil {
 			if d.TranslateErr != nil {
@@ -466,7 +458,12 @@ func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int6
 			}
 			span.RecordError(err)
 		}
+		span.End()
 	}()
+	span.SetAttributes(
+		attribute.String("key", key),
+		attribute.Int64("ttl", ttl),
+	)
 
 	result, err := d.execute(ctx, "create_sql", d.CreateSQL, key, ttl, value, key)
 	if err != nil {

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -64,6 +64,7 @@ type Dialect interface {
 	AfterPrefix(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
 	After(ctx context.Context, rev, limit int64) (*sql.Rows, error)
 	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (int64, error)
+	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
 	DeleteRevision(ctx context.Context, revision int64) error
 	GetCompactRevision(ctx context.Context) (int64, int64, error)
@@ -612,6 +613,28 @@ func (s *SQLLog) Append(ctx context.Context, event *server.Event) (int64, error)
 	if err != nil {
 		return 0, err
 	}
+	select {
+	case s.notify <- rev:
+	default:
+	}
+	return rev, nil
+}
+
+func (s *SQLLog) Create(ctx context.Context, key string, value []byte, lease int64) (int64, error) {
+	var err error
+	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+	span.SetAttributes(attribute.String("key", key))
+
+	rev, err := s.d.Create(ctx, key, value, lease)
+	if err != nil {
+		return 0, err
+	}
+	span.SetAttributes(attribute.Int64("revision", rev))
+
 	select {
 	case s.notify <- rev:
 	default:


### PR DESCRIPTION
### Description
This PR improves the create method by moving the logic into one query.

### Query
The create query:
- If there is no previous entry for a given key the query inserts the new row with the key and its value.
- If there is a previous entry for a given key exists:
  -  where the previous entry is not a deleted entry, the query inserts the new row with the key and its value.
  -  where the previous entry is a deleted entry, the query does nothing.

Then we check if any rows have been affected by the query, if not we return a key exists error.

### Index
Note: we will make an update to the `kine_name_index` when we update the schema version to include `delete`. This will allow us to have a covering index for the new create query.


