### PR TITLE
Disable kine metrics by default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,7 +143,7 @@ var (
 					logrus.WithError(err).Warning("Failed to shutdown OpenTelemetry SDK")
 				}
 			}
-			if rootCmdOpts.metrics && metricsServer != nil {
+			if metricsServer != nil {
 				if err := metricsServer.Shutdown(stopCtx); err != nil {
 					logrus.WithError(err).Fatal("Failed to shutdown metrics endpoint")
 				}
@@ -178,7 +178,7 @@ func init() {
 	rootCmd.Flags().Uint64Var(&rootCmdOpts.watchAvailableStorageMinBytes, "watch-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, then the --low-available-storage-action is performed")
 	rootCmd.Flags().StringVar(&rootCmdOpts.lowAvailableStorageAction, "low-available-storage-action", "none", "Action to perform in case the available storage is low. One of (none|handover|terminate). none means no action is performed. handover means the dqlite node will handover its leadership role, if any. terminate means this dqlite node will shutdown")
 	rootCmd.Flags().StringVar(&rootCmdOpts.admissionControlPolicy, "admission-control-policy", "allow-all", "Transaction admission control policy to use. One of (allow-all|limit-concurrent-transactions). Set to allow-all to disable the admission control")
-	// TODO(MK-1408): This value is highly depends on underlying hardware, thus making the default value a bit useless. The linked card will implement a dynamic way to set this value.
+	// TODO(MK-1408): This value is highly dependent on underlying hardware, thus making the default value a bit useless. The linked card will implement a dynamic way to set this value.
 	rootCmd.Flags().Int64Var(&rootCmdOpts.acpLimitMaxConcurrentTxn, "admission-control-policy-limit-max-concurrent-transactions", 300, "Maximum number of transactions that are allowed to run concurrently. Transactions will not be admitted after the limit is reached.")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.acpOnlyWriteQueries, "admission-control-only-for-write-queries", false, "If set, admission control will only be applied to write queries.")
 


### PR DESCRIPTION
## Description
Disable kine metrics by default and shutdown the server. 

Closes https://github.com/canonical/k8s-dqlite/issues/138 https://github.com/canonical/k8s-dqlite/issues/137