### PR TITLE
Dqlite arm64 build fix

### DIFF
--- a/hack/dynamic-dqlite.sh
+++ b/hack/dynamic-dqlite.sh
@@ -123,7 +123,7 @@ fi
 )
 
 export CGO_CFLAGS="-I${INSTALL_DIR}/include"
-export CGO_LDFLAGS="-L${INSTALL_DIR}/lib -ldqlite -luv -llz4 -lsqlite3"
+export CGO_LDFLAGS="-L${INSTALL_DIR}/lib -ldqlite -luv -llz4 -lsqlite3 -Wl,-z,stack-size=1048576"
 export LD_LIBRARY_PATH="${INSTALL_DIR}/lib"
 
 echo "Libraries are in '${INSTALL_DIR}/lib'"

--- a/hack/static-dqlite.sh
+++ b/hack/static-dqlite.sh
@@ -155,4 +155,4 @@ fi
 )
 
 export CGO_CFLAGS="-I${INSTALL_DIR}/include"
-export CGO_LDFLAGS="-L${INSTALL_DIR}/lib -luv -ldqlite -llz4 -lsqlite3"
+export CGO_LDFLAGS="-L${INSTALL_DIR}/lib -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576"


### PR DESCRIPTION
## Description
The Juju team discovered segfault issues building dqlite on arm64 machines, this flag addresses the issues: `-Wl,-z,stack-size=1048576`
See: https://wiki.musl-libc.org/functional-differences-from-glibc.html#Thread-stack-size