### PR TITLE
Make connection pool configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Steps:
     make static
     sudo ./bin/static/k8s-dqlite \
       --storage-dir /var/snap/microk8s/current/var/kubernetes/backend \
-      --listen unix:///var/snap/microk8s/current/var/kubernetes/backend/kine.sock
+      --listen unix:///var/snap/microk8s/current/var/kubernetes/backend/kine.sock:12379
     ```
 
 7. While developing and making changes to `k8s-dqlite`, just restart k8s-dqlite

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,11 @@ var (
 		otel                   bool
 		otelAddress            string
 
+		datastoreMaxIdleConnections    int
+		datastoreMaxOpenConnections    int
+		datastoreConnectionMaxLifetime time.Duration
+		datastoreConnectionMaxIdleTime time.Duration
+
 		watchAvailableStorageInterval time.Duration
 		watchAvailableStorageMinBytes uint64
 		lowAvailableStorageAction     string
@@ -108,6 +113,10 @@ var (
 				rootCmdOpts.admissionControlPolicy,
 				rootCmdOpts.acpLimitMaxConcurrentTxn,
 				rootCmdOpts.acpOnlyWriteQueries,
+				rootCmdOpts.datastoreMaxIdleConnections,
+				rootCmdOpts.datastoreMaxOpenConnections,
+				rootCmdOpts.datastoreConnectionMaxLifetime,
+				rootCmdOpts.datastoreConnectionMaxIdleTime,
 				rootCmdOpts.watchQueryTimeout,
 			)
 			if err != nil {
@@ -176,6 +185,10 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootCmdOpts.otel, "otel", false, "enable traces endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.otelAddress, "otel-listen", "127.0.0.1:4317", "listen address for OpenTelemetry endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
+	rootCmd.Flags().IntVar(&rootCmdOpts.datastoreMaxIdleConnections, "datastore-max-idle-connections", 5, "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.")
+	rootCmd.Flags().IntVar(&rootCmdOpts.datastoreMaxOpenConnections, "datastore-max-open-connections", 5, "Maximum number of open connections used by datastore. If value <= 0, then there is no limit")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.datastoreConnectionMaxLifetime, "datastore-connection-max-lifetime", 60*time.Second, "Maximum amount of time a connection may be reused. If value <= 0, then there is no limit.")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.datastoreConnectionMaxIdleTime, "datastore-connection-max-idle-time", 0*time.Second, "Maximum amount of time a connection may be idle before being closed. If value <= 0, then there is no limit.")
 	rootCmd.Flags().DurationVar(&rootCmdOpts.watchAvailableStorageInterval, "watch-storage-available-size-interval", 5*time.Second, "Interval to check if the disk is running low on space. Set to 0 to disable the periodic disk size check")
 	rootCmd.Flags().Uint64Var(&rootCmdOpts.watchAvailableStorageMinBytes, "watch-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, then the --low-available-storage-action is performed")
 	rootCmd.Flags().StringVar(&rootCmdOpts.lowAvailableStorageAction, "low-available-storage-action", "none", "Action to perform in case the available storage is low. One of (none|handover|terminate). none means no action is performed. handover means the dqlite node will handover its leadership role, if any. terminate means this dqlite node will shutdown")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -32,10 +33,7 @@ var (
 		otel                   bool
 		otelAddress            string
 
-		datastoreMaxIdleConnections    int
-		datastoreMaxOpenConnections    int
-		datastoreConnectionMaxLifetime time.Duration
-		datastoreConnectionMaxIdleTime time.Duration
+		connectionPoolConfig generic.ConnectionPoolConfig
 
 		watchAvailableStorageInterval time.Duration
 		watchAvailableStorageMinBytes uint64
@@ -113,10 +111,7 @@ var (
 				rootCmdOpts.admissionControlPolicy,
 				rootCmdOpts.acpLimitMaxConcurrentTxn,
 				rootCmdOpts.acpOnlyWriteQueries,
-				rootCmdOpts.datastoreMaxIdleConnections,
-				rootCmdOpts.datastoreMaxOpenConnections,
-				rootCmdOpts.datastoreConnectionMaxLifetime,
-				rootCmdOpts.datastoreConnectionMaxIdleTime,
+				rootCmdOpts.connectionPoolConfig,
 				rootCmdOpts.watchQueryTimeout,
 			)
 			if err != nil {
@@ -185,10 +180,10 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootCmdOpts.otel, "otel", false, "enable traces endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.otelAddress, "otel-listen", "127.0.0.1:4317", "listen address for OpenTelemetry endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
-	rootCmd.Flags().IntVar(&rootCmdOpts.datastoreMaxIdleConnections, "datastore-max-idle-connections", 5, "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.")
-	rootCmd.Flags().IntVar(&rootCmdOpts.datastoreMaxOpenConnections, "datastore-max-open-connections", 5, "Maximum number of open connections used by datastore. If value <= 0, then there is no limit")
-	rootCmd.Flags().DurationVar(&rootCmdOpts.datastoreConnectionMaxLifetime, "datastore-connection-max-lifetime", 60*time.Second, "Maximum amount of time a connection may be reused. If value <= 0, then there is no limit.")
-	rootCmd.Flags().DurationVar(&rootCmdOpts.datastoreConnectionMaxIdleTime, "datastore-connection-max-idle-time", 0*time.Second, "Maximum amount of time a connection may be idle before being closed. If value <= 0, then there is no limit.")
+	rootCmd.Flags().IntVar(&rootCmdOpts.connectionPoolConfig.MaxIdle, "datastore-max-idle-connections", 5, "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.")
+	rootCmd.Flags().IntVar(&rootCmdOpts.connectionPoolConfig.MaxOpen, "datastore-max-open-connections", 5, "Maximum number of open connections used by datastore. If value <= 0, then there is no limit")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.connectionPoolConfig.MaxLifetime, "datastore-connection-max-lifetime", 60*time.Second, "Maximum amount of time a connection may be reused. If value <= 0, then there is no limit.")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.connectionPoolConfig.MaxIdleTime, "datastore-connection-max-idle-time", 0*time.Second, "Maximum amount of time a connection may be idle before being closed. If value <= 0, then there is no limit.")
 	rootCmd.Flags().DurationVar(&rootCmdOpts.watchAvailableStorageInterval, "watch-storage-available-size-interval", 5*time.Second, "Interval to check if the disk is running low on space. Set to 0 to disable the periodic disk size check")
 	rootCmd.Flags().Uint64Var(&rootCmdOpts.watchAvailableStorageMinBytes, "watch-storage-available-size-min-bytes", 10*1024*1024, "Minimum required available disk size (in bytes) to continue operation. If available disk space gets below this threshold, then the --low-available-storage-action is performed")
 	rootCmd.Flags().StringVar(&rootCmdOpts.lowAvailableStorageAction, "low-available-storage-action", "none", "Action to perform in case the available storage is low. One of (none|handover|terminate). none means no action is performed. handover means the dqlite node will handover its leadership role, if any. terminate means this dqlite node will shutdown")

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -24,16 +24,16 @@ func init() {
 	}
 }
 
-func New(ctx context.Context, datasourceName string, tlsInfo tls.Config) (server.Backend, error) {
-	backend, _, err := NewVariant(ctx, datasourceName)
+func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+	backend, _, err := NewVariant(ctx, datasourceName, connectionPoolConfig)
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, datasourceName string) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
 	logrus.Printf("New kine for dqlite")
 
 	// Driver name will be extracted from query parameters
-	backend, generic, err := sqlite.NewVariant(ctx, "", datasourceName)
+	backend, generic, err := sqlite.NewVariant(ctx, "", datasourceName, connectionPoolConfig)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -24,12 +24,12 @@ func init() {
 	}
 }
 
-func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connectionPoolConfig *generic.ConnectionPoolConfig) (server.Backend, error) {
 	backend, _, err := NewVariant(ctx, datasourceName, connectionPoolConfig)
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
 	logrus.Printf("New kine for dqlite")
 
 	// Driver name will be extracted from query parameters

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -180,7 +180,13 @@ func configureConnectionPooling(connPoolConfig ConnectionPoolConfig, db *sql.DB)
 		connPoolConfig.MaxIdle = defaultMaxIdleConns
 	}
 
-	logrus.Infof("Configuring database connection pooling: maxIdleConns=%d, maxOpenConns=%d, connMaxLifetime=%s, connMaxIdleTime=%s ", connPoolConfig.MaxIdle, connPoolConfig.MaxOpen, connPoolConfig.MaxLifetime, connPoolConfig.MaxIdleTime)
+	logrus.Infof(
+		"Configuring database connection pooling: maxIdleConns=%d, maxOpenConns=%d, connMaxLifetime=%s, connMaxIdleTime=%s ",
+		connPoolConfig.MaxIdle,
+		connPoolConfig.MaxOpen,
+		connPoolConfig.MaxLifetime,
+		connPoolConfig.MaxIdleTime,
+	)
 	db.SetMaxIdleConns(connPoolConfig.MaxIdle)
 	db.SetMaxOpenConns(connPoolConfig.MaxOpen)
 	db.SetConnMaxLifetime(connPoolConfig.MaxLifetime)

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -172,7 +172,7 @@ type ConnectionPoolConfig struct {
 	MaxIdleTime time.Duration
 }
 
-func configureConnectionPooling(connPoolConfig ConnectionPoolConfig, db *sql.DB) {
+func configureConnectionPooling(connPoolConfig *ConnectionPoolConfig, db *sql.DB) {
 	// behavior of database/sql - zero means defaultMaxIdleConns; negative means 0
 	if connPoolConfig.MaxIdle < 0 {
 		connPoolConfig.MaxIdle = 0
@@ -181,7 +181,7 @@ func configureConnectionPooling(connPoolConfig ConnectionPoolConfig, db *sql.DB)
 	}
 
 	logrus.Infof(
-		"Configuring database connection pooling: maxIdleConns=%d, maxOpenConns=%d, connMaxLifetime=%s, connMaxIdleTime=%s ",
+		"Configuring database connection pooling: maxIdleConns=%d, maxOpenConns=%d, connMaxLifetime=%v, connMaxIdleTime=%v ",
 		connPoolConfig.MaxIdle,
 		connPoolConfig.MaxOpen,
 		connPoolConfig.MaxLifetime,
@@ -225,7 +225,7 @@ func openAndTest(driverName, dataSourceName string) (*sql.DB, error) {
 	return db, nil
 }
 
-func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig ConnectionPoolConfig, paramCharacter string, numbered bool) (*Generic, error) {
+func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig *ConnectionPoolConfig, paramCharacter string, numbered bool) (*Generic, error) {
 	var (
 		db  *sql.DB
 		err error

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -32,8 +32,8 @@ type opts struct {
 	admissionControlOnlyWriteQueries            bool
 }
 
-func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
-	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName)
+func New(ctx context.Context, dataSourceName string, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName, connectionPoolConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
 	const retryAttempts = 300
 
 	opts, err := parseOpts(dataSourceName)
@@ -65,7 +65,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		dataSourceName = "./db/state.db?_journal=WAL&cache=shared"
 	}
 
-	dialect, err := generic.Open(ctx, driverName, opts.dsn, "?", false)
+	dialect, err := generic.Open(ctx, driverName, opts.dsn, connectionPoolConfig, "?", false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -32,7 +32,7 @@ type opts struct {
 	admissionControlOnlyWriteQueries            bool
 }
 
-func New(ctx context.Context, dataSourceName string, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (server.Backend, error) {
 	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName, connectionPoolConfig)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func New(ctx context.Context, dataSourceName string, connectionPoolConfig generi
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
 	const retryAttempts = 300
 
 	opts, err := parseOpts(dataSourceName)

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"path"
 	"testing"
+	"time"
 
+	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/sirupsen/logrus"
 )
@@ -51,7 +53,13 @@ func TestMigration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if _, err := sqlite.New(ctx, dbPath); err != nil {
+	connPoolConfig := generic.ConnectionPoolConfig{
+		MaxIdle:     5,
+		MaxOpen:     5,
+		MaxLifetime: 60 * time.Second,
+		MaxIdleTime: 0 * time.Second,
+	}
+	if _, err := sqlite.New(ctx, dbPath, connPoolConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -57,7 +57,7 @@ func TestMigration(t *testing.T) {
 		MaxIdle:     5,
 		MaxOpen:     5,
 		MaxLifetime: 60 * time.Second,
-		MaxIdleTime: 0 * time.Second,
+		MaxIdleTime: 60 * time.Second,
 	}
 	if _, err := sqlite.New(ctx, dbPath, connPoolConfig); err != nil {
 		t.Fatal(err)

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -57,7 +57,7 @@ func TestMigration(t *testing.T) {
 		MaxIdle:     5,
 		MaxOpen:     5,
 		MaxLifetime: 60 * time.Second,
-		MaxIdleTime: 60 * time.Second,
+		MaxIdleTime: 0 * time.Second,
 	}
 	if _, err := sqlite.New(ctx, dbPath, connPoolConfig); err != nil {
 		t.Fatal(err)

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -59,7 +59,7 @@ func TestMigration(t *testing.T) {
 		MaxLifetime: 60 * time.Second,
 		MaxIdleTime: 0 * time.Second,
 	}
-	if _, err := sqlite.New(ctx, dbPath, connPoolConfig); err != nil {
+	if _, err := sqlite.New(ctx, dbPath, &connPoolConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/dqlite"
+	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	"github.com/canonical/k8s-dqlite/pkg/kine/tls"
@@ -26,9 +27,10 @@ const (
 )
 
 type Config struct {
-	GRPCServer *grpc.Server
-	Listener   string
-	Endpoint   string
+	GRPCServer           *grpc.Server
+	Listener             string
+	Endpoint             string
+	ConnectionPoolConfig generic.ConnectionPoolConfig
 
 	tls.Config
 }
@@ -180,9 +182,9 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	switch driver {
 	case SQLiteBackend:
 		leaderElect = false
-		backend, err = sqlite.New(ctx, dsn)
+		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn, cfg.Config)
+		backend, err = dqlite.New(ctx, dsn, cfg.Config, cfg.ConnectionPoolConfig)
 	default:
 		return false, nil, fmt.Errorf("storage backend is not defined")
 	}

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -182,9 +182,9 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	switch driver {
 	case SQLiteBackend:
 		leaderElect = false
-		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
+		backend, err = sqlite.New(ctx, dsn, &cfg.ConnectionPoolConfig)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn, cfg.Config, cfg.ConnectionPoolConfig)
+		backend, err = dqlite.New(ctx, dsn, cfg.Config, &cfg.ConnectionPoolConfig)
 	default:
 		return false, nil, fmt.Errorf("storage backend is not defined")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,10 @@ func New(
 	admissionControlPolicy string,
 	admissionControlPolicyLimitMaxConcurrentTxn int64,
 	admissionControlOnlyWriteQueries bool,
+	datastoreMaxIdleConnections int,
+	datastoreMaxOpenConnections int,
+	datastoreConnectionMaxLifetime time.Duration,
+	datastoreConnectionMaxIdleTime time.Duration,
 	watchQueryTimeout time.Duration,
 ) (*Server, error) {
 	var (
@@ -221,7 +225,11 @@ func New(
 		}
 		options = append(options, app.WithTLS(listen, dial))
 	}
-
+	// set datastore connection pool options
+	kineConfig.ConnectionPoolConfig.MaxIdle = datastoreMaxIdleConnections
+	kineConfig.ConnectionPoolConfig.MaxOpen = datastoreMaxOpenConnections
+	kineConfig.ConnectionPoolConfig.MaxLifetime = datastoreConnectionMaxLifetime
+	kineConfig.ConnectionPoolConfig.MaxIdleTime = datastoreConnectionMaxIdleTime
 	// handle tuning parameters
 	if exists, err := fileExists(dir, "tuning.yaml"); err != nil {
 		return nil, fmt.Errorf("failed to check for tuning.yaml: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/go-dqlite"
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
+	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	kine_tls "github.com/canonical/k8s-dqlite/pkg/kine/tls"
@@ -69,10 +70,7 @@ func New(
 	admissionControlPolicy string,
 	admissionControlPolicyLimitMaxConcurrentTxn int64,
 	admissionControlOnlyWriteQueries bool,
-	datastoreMaxIdleConnections int,
-	datastoreMaxOpenConnections int,
-	datastoreConnectionMaxLifetime time.Duration,
-	datastoreConnectionMaxIdleTime time.Duration,
+	connectionPoolConfig generic.ConnectionPoolConfig,
 	watchQueryTimeout time.Duration,
 ) (*Server, error) {
 	var (
@@ -226,10 +224,7 @@ func New(
 		options = append(options, app.WithTLS(listen, dial))
 	}
 	// set datastore connection pool options
-	kineConfig.ConnectionPoolConfig.MaxIdle = datastoreMaxIdleConnections
-	kineConfig.ConnectionPoolConfig.MaxOpen = datastoreMaxOpenConnections
-	kineConfig.ConnectionPoolConfig.MaxLifetime = datastoreConnectionMaxLifetime
-	kineConfig.ConnectionPoolConfig.MaxIdleTime = datastoreConnectionMaxIdleTime
+	kineConfig.ConnectionPoolConfig = connectionPoolConfig
 	// handle tuning parameters
 	if exists, err := fileExists(dir, "tuning.yaml"); err != nil {
 		return nil, fmt.Errorf("failed to check for tuning.yaml: %w", err)


### PR DESCRIPTION
## Make Connection Pool configurable

We use a connection pool to talk with the database. This connection pool can be configured.
Existing connections are not actively closed by us, we lazily close them via the connection pool configuration.
Through this PR we can set the connection pool configurations via flags.

This PR attempts to mitigate an issue where the leader node is killed and connections are "hanging" on the old connection of the killed node.

## Configuration

Sql allows us to configure these parameters:
- [SetMaxOpenConns](https://pkg.go.dev/database/sql#DB.SetMaxOpenConns)
- [SetMaxIdleConns](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns)
- [SetConnMaxIdleTime](https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime)
- [SetConnMaxLifetime](https://pkg.go.dev/database/sql#DB.SetConnMaxLifetime)

## Current Configuration

We currently use:
- MaxIdleConns: 5
- MaxOpenConns: 5
- ConnMaxLifetime: 60s
- ConnMaxIdleTime: undefined

## Optimal default values
From a discussion with the dqlite team:
MaxConnections
- lxd team allows only one connection
- benchmarking shows that the best write throughput from dqlite shows you should use at least 2 connections, 5 seems reasonable
- Not certain whether dqlite can take advantage of more than 5 simultaneous connections for reads, if so bumping this number for very large clusters would be advisable.
Max ConnLifetime
- shorter connection lifetimes mean a quicker response to close connections to dead leader nodes, however this can be wasteful on a healthy cluster.
