### PR TITLE
After query timeout in watcher's poll loop

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -2,7 +2,7 @@ name: cla-check
 
 on:
   pull_request:
-    branches: [master, default]
+    branches: [master, default, 1.29]
 
 jobs:
   cla-check:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: End To End
 
 on:
   push:
-    branches: [master]
+    branches: [master, 1.29]
   pull_request:
 
 jobs:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [master]
+    branches: [master, 1.29]
   pull_request:
 
 jobs:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var (
 		admissionControlPolicy   string
 		acpLimitMaxConcurrentTxn int64
 		acpOnlyWriteQueries      bool
+		pollAfterTimeout         time.Duration
 	}
 
 	rootCmd = &cobra.Command{
@@ -79,6 +80,7 @@ var (
 				rootCmdOpts.admissionControlPolicy,
 				rootCmdOpts.acpLimitMaxConcurrentTxn,
 				rootCmdOpts.acpOnlyWriteQueries,
+				rootCmdOpts.pollAfterTimeout,
 			)
 			if err != nil {
 				logrus.WithError(err).Fatal("Failed to create server")
@@ -141,4 +143,5 @@ func init() {
 	// TODO(MK-1408): This value is highly dependend on underlying hardware, thus making the default value a bit useless. The linked card will implement a dynamic way to set this value.
 	rootCmd.Flags().Int64Var(&rootCmdOpts.acpLimitMaxConcurrentTxn, "admission-control-policy-limit-max-concurrent-transactions", 300, "Maximum number of transactions that are allowed to run concurrently. Transactions will not be admitted after the limit is reached.")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.acpOnlyWriteQueries, "admission-control-only-for-write-queries", false, "If set, admission control will only be applied to write queries.")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.pollAfterTimeout, "poll-after-timeout", 20*time.Second, "Timeout on the after query during the poll loop. If timeout is reached, the poll loop will be re-triggered")
 }

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/canonical/go-dqlite"
 	"github.com/canonical/go-dqlite/driver"
@@ -25,11 +26,11 @@ func init() {
 	}
 }
 
-func New(ctx context.Context, datasourceName string, tlsInfo tls.Config) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, pollAfterTimeout time.Duration) (server.Backend, error) {
 	logrus.Printf("New kine for dqlite")
 
 	// Driver name will be extracted from query parameters
-	backend, generic, err := sqlite.NewVariant(ctx, "", datasourceName)
+	backend, generic, err := sqlite.NewVariant(ctx, "", datasourceName, pollAfterTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/kine/drivers/dqlite/no_dqlite.go
+++ b/pkg/kine/drivers/dqlite/no_dqlite.go
@@ -5,11 +5,12 @@ package dqlite
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	"github.com/canonical/k8s-dqlite/pkg/kine/tls"
 )
 
-func New(ctx context.Context, datasourceName string, tlsInfo tls.Config) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, pollAfterTimeout time.Duration) (server.Backend, error) {
 	return nil, fmt.Errorf("dqlite is not support, compile with \"-tags dqlite\"")
 }

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -31,8 +31,8 @@ type opts struct {
 	admissionControlOnlyWriteQueries            bool
 }
 
-func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
-	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName)
+func New(ctx context.Context, dataSourceName string, pollAfterTimeout time.Duration) (server.Backend, error) {
+	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName, pollAfterTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, driverName, dataSourceName string, pollAfterTimeout time.Duration) (server.Backend, *generic.Generic, error) {
 	const retryAttempts = 300
 
 	opts, err := parseOpts(dataSourceName)
@@ -64,7 +64,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		dataSourceName = "./db/state.db?_journal=WAL&cache=shared"
 	}
 
-	dialect, err := generic.Open(ctx, driverName, opts.dsn, "?", false)
+	dialect, err := generic.Open(ctx, driverName, opts.dsn, "?", false, pollAfterTimeout)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 )
@@ -50,7 +51,8 @@ func TestMigration(t *testing.T) {
 	setupV0(db)
 
 	ctx := context.Background()
-	if _, err := sqlite.New(ctx, dbPath); err != nil {
+	pollAfterTimeout := 20 * time.Second
+	if _, err := sqlite.New(ctx, dbPath, pollAfterTimeout); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/dqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
@@ -26,10 +27,10 @@ const (
 )
 
 type Config struct {
-	GRPCServer *grpc.Server
-	Listener   string
-	Endpoint   string
-
+	GRPCServer       *grpc.Server
+	Listener         string
+	Endpoint         string
+	PollAfterTimeout time.Duration
 	tls.Config
 }
 
@@ -182,9 +183,9 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	switch driver {
 	case SQLiteBackend:
 		leaderElect = false
-		backend, err = sqlite.New(ctx, dsn)
+		backend, err = sqlite.New(ctx, dsn, cfg.PollAfterTimeout)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn, cfg.Config)
+		backend, err = dqlite.New(ctx, dsn, cfg.Config, cfg.PollAfterTimeout)
 	default:
 		return false, nil, fmt.Errorf("storage backend is not defined")
 	}

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -3,6 +3,7 @@ package sqllog
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -44,6 +45,7 @@ type Dialect interface {
 	IsFill(key string) bool
 	GetSize(ctx context.Context) (int64, error)
 	GetCompactInterval() time.Duration
+	GetPollAfterQueryTimeout() time.Duration
 	GetPollInterval() time.Duration
 }
 
@@ -392,9 +394,14 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 		}
 		waitForMore = true
 
-		rows, err := s.d.After(s.ctx, last, 500)
+		afterQueryCtx, cancel := context.WithTimeout(s.ctx, s.d.GetPollAfterQueryTimeout())
+		defer cancel()
+
+		rows, err := s.d.After(afterQueryCtx, last, 500)
 		if err != nil {
-			logrus.Errorf("fail to list latest changes: %v", err)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				logrus.Errorf("fail to list latest changes: %v", err)
+			}
 			continue
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,6 +66,7 @@ func New(
 	admissionControlPolicy string,
 	admissionControlPolicyLimitMaxConcurrentTxn int64,
 	admissionControlOnlyWriteQueries bool,
+	pollAfterTimeout time.Duration,
 ) (*Server, error) {
 	var (
 		options         []app.Option
@@ -273,6 +274,7 @@ func New(
 
 	kineConfig.Listener = listen
 	kineConfig.Endpoint = fmt.Sprintf("dqlite://k8s?%s", params.Encode())
+	kineConfig.PollAfterTimeout = pollAfterTimeout
 
 	return &Server{
 		app:        app,

--- a/test/util_test_dqlite.go
+++ b/test/util_test_dqlite.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
@@ -31,7 +32,8 @@ func makeEndpointConfig(ctx context.Context, tb testing.TB) endpoint.Config {
 	})
 
 	return endpoint.Config{
-		Listener: fmt.Sprintf("unix://%s/listen.sock", dir),
-		Endpoint: fmt.Sprintf("dqlite://k8s-%d?driver-name=%s", nextIdx, app.Driver()),
+		Listener:         fmt.Sprintf("unix://%s/listen.sock", dir),
+		Endpoint:         fmt.Sprintf("dqlite://k8s-%d?driver-name=%s", nextIdx, app.Driver()),
+		PollAfterTimeout: 20 * time.Second,
 	}
 }

--- a/test/util_test_sqlite.go
+++ b/test/util_test_sqlite.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 )
@@ -14,7 +15,8 @@ func makeEndpointConfig(_ context.Context, tb testing.TB) endpoint.Config {
 	dir := tb.TempDir()
 
 	return endpoint.Config{
-		Listener: fmt.Sprintf("unix://%s/listen.sock", dir),
-		Endpoint: fmt.Sprintf("sqlite://%s/data.db", dir),
+		Listener:         fmt.Sprintf("unix://%s/listen.sock", dir),
+		Endpoint:         fmt.Sprintf("sqlite://%s/data.db", dir),
+		PollAfterTimeout: 20 * time.Second,
 	}
 }


### PR DESCRIPTION
## Description
This PR adds a timeout on long running after queries which are part of the watcher's poll loop. 
The timeout is configurable using the `poll-after-timeout` flag.

## Context
This PR addresses issues raised in microk8s where after the leader node is removed from the cluster the remaining nodes also go into `NotReady` state for ~20 minutes. This timeout helps the responsiveness of the cluster after loosing its leader.

## Note to reviewers
The largest part of this code change is passing the timeout arg to the poll loop.
Look at files in this order: root.go -> server.go -> endpoint.go -> sqlite.go/ dqlite.go -> generic.go -> sql.go
