### PR TITLE
Watcher query timeout Backport Microk8s 1.28 

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -23,7 +23,7 @@ jobs:
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
       - name: Install snapcraft
-        run: sudo snap install snapcraft --classic
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
       - name: Build snap
         run: |
           sg lxd -c 'snapcraft --use-lxd'

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -x
           sudo snap install k8s-dqlite.snap --classic --dangerous
-          sudo snap install go --channel 1.18/stable --classic
+          sudo snap install go --channel 1.21/stable --classic
           sudo apt install git
           git clone https://github.com/etcd-io/etcd.git
           cd etcd

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - 1.28
 
 jobs:
   build:

--- a/app/app.go
+++ b/app/app.go
@@ -111,5 +111,5 @@ func init() {
 	dqliteCmd.Flags().StringVar(&opts.ProfilingListen, "profiling-listen", opts.ProfilingListen, "listen address for pprof endpoint")
 	dqliteCmd.Flags().BoolVar(&opts.DiskMode, "disk-mode", opts.DiskMode, "(experimental) run dqlite store in disk mode")
 	dqliteCmd.Flags().UintVar(&opts.ClientSessionCacheSize, "tls-client-session-cache-size", opts.ClientSessionCacheSize, "ClientCacheSession size for dial TLS config")
-	dqliteCmd.Flags().DurationVar(&opts.WatchQueryTimeout, "watch-query-timeout", opts.WatchQueryTimeout, "timeout for watch query")
+	dqliteCmd.Flags().DurationVar(&opts.WatchQueryTimeout, "watch-query-timeout", opts.WatchQueryTimeout, "timeout for querying events in the watch poll loop. If timeout is reached, the poll loop will be re-triggered. The minimum value is 5 seconds.")
 }

--- a/app/app.go
+++ b/app/app.go
@@ -111,5 +111,5 @@ func init() {
 	dqliteCmd.Flags().StringVar(&opts.ProfilingListen, "profiling-listen", opts.ProfilingListen, "listen address for pprof endpoint")
 	dqliteCmd.Flags().BoolVar(&opts.DiskMode, "disk-mode", opts.DiskMode, "(experimental) run dqlite store in disk mode")
 	dqliteCmd.Flags().UintVar(&opts.ClientSessionCacheSize, "tls-client-session-cache-size", opts.ClientSessionCacheSize, "ClientCacheSession size for dial TLS config")
-	dqliteCmd.Flags().DurationVar(&opts.WatchQueryTimeout, "watch-query-timeout", opts.WatchQueryTimeout, "timeout for querying events in the watch poll loop. If timeout is reached, the poll loop will be re-triggered. The minimum value is 5 seconds.")
+	dqliteCmd.Flags().DurationVar(&opts.WatchQueryTimeout, "watch-query-timeout", opts.WatchQueryTimeout, "timeout for querying events in the watch poll loop. If the timeout is reached, the poll loop will be re-triggered. The minimum value is 5 seconds.")
 }

--- a/app/app.go
+++ b/app/app.go
@@ -40,6 +40,7 @@ var opts = options.Options{
 	ProfilingListen:        "127.0.0.1:40000",
 	DiskMode:               false,
 	ClientSessionCacheSize: 0,
+	WatchQueryTimeout:      20 * time.Second,
 }
 
 // liteCmd represents the base command when called without any subcommands
@@ -67,6 +68,7 @@ var dqliteCmd = &cobra.Command{
 			opts.EnableTLS,
 			opts.DiskMode,
 			opts.ClientSessionCacheSize,
+			opts.WatchQueryTimeout,
 		)
 		if err != nil {
 			log.Fatalf("Failed to start server: %s\n", err)
@@ -109,4 +111,5 @@ func init() {
 	dqliteCmd.Flags().StringVar(&opts.ProfilingListen, "profiling-listen", opts.ProfilingListen, "listen address for pprof endpoint")
 	dqliteCmd.Flags().BoolVar(&opts.DiskMode, "disk-mode", opts.DiskMode, "(experimental) run dqlite store in disk mode")
 	dqliteCmd.Flags().UintVar(&opts.ClientSessionCacheSize, "tls-client-session-cache-size", opts.ClientSessionCacheSize, "ClientCacheSession size for dial TLS config")
+	dqliteCmd.Flags().DurationVar(&opts.WatchQueryTimeout, "watch-query-timeout", opts.WatchQueryTimeout, "timeout for watch query")
 }

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package options
 
+import "time"
+
 // Options is the list of options for running k8s-dqlite.
 type Options struct {
 	StorageDir             string
@@ -26,4 +28,5 @@ type Options struct {
 	ProfilingListen        string
 	DiskMode               bool
 	ClientSessionCacheSize uint
+	WatchQueryTimeout      time.Duration
 }

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	k8s.io/component-base v0.18.0
 )
 
-replace github.com/rancher/kine => github.com/canonical/kine v0.4.1-k8s-dqlite.10
+replace github.com/rancher/kine => github.com/canonical/kine 1.28

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	k8s.io/component-base v0.18.0
 )
 
-replace github.com/rancher/kine => github.com/canonical/kine 1.28
+replace github.com/rancher/kine => github.com/canonical/kine v0.4.1-k8s-dqlite.11

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/canonical/go-dqlite v1.11.8 h1:yRnVotjd7xUXdVvTW2RoVWeUlBM7oF+/ylQfQlu9bQ8=
 github.com/canonical/go-dqlite v1.11.8/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/kine v0.4.1-k8s-dqlite.10 h1:4R7m9tGV9RW6zwWWOSlCQEzww/0W5GpIRyZ1xvlA198=
-github.com/canonical/kine v0.4.1-k8s-dqlite.10/go.mod h1:0xLHwFfgn9loFiIQTch7KBo7e0D2FHdCEei+9Vq5F04=
+github.com/canonical/kine v0.4.1-k8s-dqlite.11 h1:1bOhb9j/F0cogBjNIaOqzXQ9hsJDDEwDP4WSKU1KUPY=
+github.com/canonical/kine v0.4.1-k8s-dqlite.11/go.mod h1:0xLHwFfgn9loFiIQTch7KBo7e0D2FHdCEei+9Vq5F04=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ var (
 	defaultKineEp = "tcp://127.0.0.1:12379"
 )
 
-func New(dir string, listen string, enableTLS bool, diskMode bool, clientSessionCacheSize uint) (*Server, error) {
+func New(dir string, listen string, enableTLS bool, diskMode bool, clientSessionCacheSize uint, watchQueryTimeout time.Duration) (*Server, error) {
 	// Check if we're initializing a new node (i.e. there's an init.yaml).
 	// dir: the directory where data will be stored as well as where the init.yaml
 	//       and certificates should be found
@@ -183,8 +183,8 @@ func New(dir string, listen string, enableTLS bool, diskMode bool, clientSession
 	if v := cfg.DqliteTuning.KinePollInterval; v != nil {
 		e = fmt.Sprintf("%s&poll-interval=%v", e, *v)
 	}
-
-	log.Printf("Connecting to kine endpoint: %s", e)
+	// Watch query timeout
+	e = fmt.Sprintf("%s&watch-query-timeout=%v", e, watchQueryTimeout)
 
 	config := endpoint.Config{
 		Listener: ep,

--- a/server/server.go
+++ b/server/server.go
@@ -186,6 +186,8 @@ func New(dir string, listen string, enableTLS bool, diskMode bool, clientSession
 	// Watch query timeout
 	e = fmt.Sprintf("%s&watch-query-timeout=%v", e, watchQueryTimeout)
 
+	log.Printf("Connecting to kine endpoint: %s", e)
+
 	config := endpoint.Config{
 		Listener: ep,
 		Endpoint: e,


### PR DESCRIPTION
## Description
Back-port watcher query timeout fix: https://github.com/canonical/k8s-dqlite/pull/162
Depends on https://github.com/canonical/kine/pull/33.