### PR TITLE
Fix list benchmark and notify CI on error

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -102,6 +102,7 @@ jobs:
       - name: Run benchmarks
         id: bench
         run: |
+          set -o pipefail
           go test                           \
               -tags libsqlite3 -v -p 1 ./...  \
               -benchmem -count $BENCH_COUNT   \
@@ -118,6 +119,7 @@ jobs:
       - name: Run benchmark for base code
         if: steps.bench-cache.outputs.cache-hit != 'true'
         run: |
+          set -o pipefail
           git fetch origin $BASE_BRANCH
           git reset --hard $BASE_SHA
           go test                           \

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -104,6 +104,7 @@ jobs:
         run: |
           set -o pipefail
           go test                           \
+              -timeout 1h                   \
               -tags libsqlite3 -v -p 1 ./...  \
               -benchmem -count $BENCH_COUNT   \
               -run "^$$" -bench .             \
@@ -123,6 +124,7 @@ jobs:
           git fetch origin $BASE_BRANCH
           git reset --hard $BASE_SHA
           go test                           \
+              -timeout 1h                   \
               -tags libsqlite3 -v -p 1 ./...  \
               -benchmem -count $BENCH_COUNT   \
               -run "^$$" -bench .             \

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -180,13 +180,13 @@ func TestList(t *testing.T) {
 
 func BenchmarkList(b *testing.B) {
 	setup := func(ctx context.Context, tx *sql.Tx, payloadSize, n int) error {
-		if err := insertMany(ctx, tx, "key", payloadSize, n*2); err != nil {
+		if err := insertMany(ctx, tx, "key", payloadSize, n); err != nil {
 			return err
 		}
-		if err := updateMany(ctx, tx, "key", payloadSize, n); err != nil {
+		if err := updateMany(ctx, tx, "key", payloadSize, (n+1)/2); err != nil {
 			return err
 		}
-		if err := deleteMany(ctx, tx, "key", n); err != nil {
+		if err := deleteMany(ctx, tx, "key", (n+1)/2); err != nil {
 			return err
 		}
 		return nil
@@ -227,7 +227,7 @@ func BenchmarkList(b *testing.B) {
 					resp, err := kine.client.Get(ctx, "key/", clientv3.WithPrefix())
 
 					g.Expect(err).To(BeNil())
-					g.Expect(resp.Kvs).To(HaveLen(b.N))
+					g.Expect(resp.Kvs).To(HaveLen((b.N + 1) / 2))
 					kine.ReportMetrics(b)
 				})
 
@@ -263,7 +263,7 @@ func BenchmarkList(b *testing.B) {
 						nextKey = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x01"
 					}
 
-					g.Expect(count).To(Equal(b.N))
+					g.Expect(count).To(Equal((b.N + 1) / 2))
 					kine.ReportMetrics(b)
 				})
 			})

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -183,10 +183,10 @@ func BenchmarkList(b *testing.B) {
 		if err := insertMany(ctx, tx, "key", payloadSize, n); err != nil {
 			return err
 		}
-		if err := updateMany(ctx, tx, "key", payloadSize, (n+1)/2); err != nil {
+		if err := updateMany(ctx, tx, "key", payloadSize, n/2); err != nil {
 			return err
 		}
-		if err := deleteMany(ctx, tx, "key", (n+1)/2); err != nil {
+		if err := deleteMany(ctx, tx, "key", n/2); err != nil {
 			return err
 		}
 		return nil

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -227,7 +227,7 @@ func BenchmarkList(b *testing.B) {
 					resp, err := kine.client.Get(ctx, "key/", clientv3.WithPrefix())
 
 					g.Expect(err).To(BeNil())
-					g.Expect(resp.Kvs).To(HaveLen((b.N + 1) / 2))
+					g.Expect(resp.Kvs).To(HaveLen(b.N))
 					kine.ReportMetrics(b)
 				})
 
@@ -263,7 +263,7 @@ func BenchmarkList(b *testing.B) {
 						nextKey = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x01"
 					}
 
-					g.Expect(count).To(Equal((b.N + 1) / 2))
+					g.Expect(count).To(Equal(b.N))
 					kine.ReportMetrics(b)
 				})
 			})


### PR DESCRIPTION
This PR fixes a problem in the List benchmark. It also makes sure that the CI pipeline for benchmarks fail if an error occurs (it was ignoring the error before).