### PR TITLE
[WIP] Make benchmark time more accurate

### DIFF
--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -95,7 +95,6 @@ func TestCompaction(t *testing.T) {
 func BenchmarkCompaction(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			kine := newKineServer(ctx, b, &kineOptions{
@@ -123,6 +122,7 @@ func BenchmarkCompaction(b *testing.B) {
 			if err := kine.backend.DoCompact(ctx); err != nil {
 				b.Fatal(err)
 			}
+			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -95,6 +95,7 @@ func TestCompaction(t *testing.T) {
 func BenchmarkCompaction(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
+			b.StopTimer()
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			kine := newKineServer(ctx, b, &kineOptions{

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -38,7 +38,6 @@ func TestCreate(t *testing.T) {
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
 			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -53,6 +52,7 @@ func BenchmarkCreate(b *testing.B) {
 				value := fmt.Sprintf("value-%d", i)
 				createKey(ctx, g, kine.client, key, value)
 			}
+			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -38,8 +38,8 @@ func TestCreate(t *testing.T) {
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			g := NewWithT(b)
 			b.StopTimer()
+			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -39,6 +39,7 @@ func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			g := NewWithT(b)
+			b.StopTimer()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -59,6 +59,7 @@ func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			g := NewWithT(b)
+			b.StopTimer()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -58,7 +58,6 @@ func TestDelete(t *testing.T) {
 func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
 			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -80,6 +79,7 @@ func BenchmarkDelete(b *testing.B) {
 				key := fmt.Sprintf("key/%d", i)
 				deleteKey(ctx, g, kine.client, key)
 			}
+			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -58,8 +58,8 @@ func TestDelete(t *testing.T) {
 func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			g := NewWithT(b)
 			b.StopTimer()
+			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -117,6 +117,7 @@ func BenchmarkGet(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			g := NewWithT(b)
+			b.StopTimer()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -138,7 +138,9 @@ func BenchmarkGet(b *testing.B) {
 			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
+				b.StartTimer()
 				resp, err := kine.client.Get(ctx, fmt.Sprintf("testKey/%d", i+1), clientv3.WithRange(""))
+				b.StopTimer()
 				g.Expect(err).To(BeNil())
 				g.Expect(resp.Kvs).To(HaveLen(1))
 			}

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -116,8 +116,8 @@ func TestGet(t *testing.T) {
 func BenchmarkGet(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			g := NewWithT(b)
 			b.StopTimer()
+			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -136,7 +136,6 @@ func BenchmarkGet(b *testing.B) {
 			})
 
 			kine.ResetMetrics()
-			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				b.StartTimer()
 				resp, err := kine.client.Get(ctx, fmt.Sprintf("testKey/%d", i+1), clientv3.WithRange(""))
@@ -144,7 +143,6 @@ func BenchmarkGet(b *testing.B) {
 				g.Expect(err).To(BeNil())
 				g.Expect(resp.Kvs).To(HaveLen(1))
 			}
-			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -101,7 +101,9 @@ func TestGet(t *testing.T) {
 				key := "testKeyFailNotFound"
 
 				// Delete key
-				deleteKey(ctx, g, kine.client, key)
+				respDel, err := deleteKey(ctx, g, kine.client, key)
+				g.Expect(err).To(BeNil())
+				g.Expect(respDel.Succeeded).To(BeTrue())
 
 				// Get key
 				resp, err := kine.client.Get(ctx, key, clientv3.WithRange(""))

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -116,7 +116,6 @@ func TestGet(t *testing.T) {
 func BenchmarkGet(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
 			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -142,6 +141,7 @@ func BenchmarkGet(b *testing.B) {
 				g.Expect(err).To(BeNil())
 				g.Expect(resp.Kvs).To(HaveLen(1))
 			}
+			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -85,6 +85,7 @@ func BenchmarkLease(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			g := NewWithT(b)
+			b.StopTimer()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -95,9 +95,10 @@ func BenchmarkLease(b *testing.B) {
 			kine.ResetMetrics()
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
+				b.StartTimer()
 				var ttl int64 = int64(i + 1)
 				resp, err := kine.client.Lease.Grant(ctx, ttl)
-
+				b.StopTimer()
 				g.Expect(err).To(BeNil())
 				g.Expect(resp.ID).To(Equal(clientv3.LeaseID(ttl)))
 				g.Expect(resp.TTL).To(Equal(ttl))

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -94,8 +94,8 @@ func BenchmarkLease(b *testing.B) {
 
 			kine.ResetMetrics()
 			for i := 0; i < b.N; i++ {
-				b.StartTimer()
 				var ttl int64 = int64(i + 1)
+				b.StartTimer()
 				resp, err := kine.client.Lease.Grant(ctx, ttl)
 				b.StopTimer()
 				g.Expect(err).To(BeNil())

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -93,7 +93,6 @@ func BenchmarkLease(b *testing.B) {
 			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
 
 			kine.ResetMetrics()
-			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				b.StartTimer()
 				var ttl int64 = int64(i + 1)
@@ -103,7 +102,6 @@ func BenchmarkLease(b *testing.B) {
 				g.Expect(resp.ID).To(Equal(clientv3.LeaseID(ttl)))
 				g.Expect(resp.TTL).To(Equal(ttl))
 			}
-			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -84,7 +84,6 @@ func TestLease(t *testing.T) {
 func BenchmarkLease(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
 			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -102,6 +101,7 @@ func BenchmarkLease(b *testing.B) {
 				g.Expect(resp.ID).To(Equal(clientv3.LeaseID(ttl)))
 				g.Expect(resp.TTL).To(Equal(ttl))
 			}
+			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -84,8 +84,8 @@ func TestLease(t *testing.T) {
 func BenchmarkLease(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			g := NewWithT(b)
 			b.StopTimer()
+			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -209,8 +209,8 @@ func BenchmarkList(b *testing.B) {
 		for _, payload := range payloads {
 			b.Run(fmt.Sprintf("%s-%s", backendType, payload.name), func(b *testing.B) {
 				b.Run("all", func(b *testing.B) {
-					g := NewWithT(b)
 					b.StopTimer()
+					g := NewWithT(b)
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
@@ -233,8 +233,8 @@ func BenchmarkList(b *testing.B) {
 				})
 
 				b.Run("pagination", func(b *testing.B) {
-					g := NewWithT(b)
 					b.StopTimer()
+					g := NewWithT(b)
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -228,7 +228,6 @@ func BenchmarkList(b *testing.B) {
 					b.StopTimer()
 					g.Expect(err).To(BeNil())
 					g.Expect(resp.Kvs).To(HaveLen((b.N + 1) / 2))
-
 					kine.ReportMetrics(b)
 				})
 
@@ -247,25 +246,24 @@ func BenchmarkList(b *testing.B) {
 					})
 
 					kine.ResetMetrics()
-					b.StartTimer()
 					nextKey := "key/"
 					endRange := clientv3.GetPrefixRangeEnd(nextKey)
 					count := 0
 					for more := true; more; {
+						b.StartTimer()
 						resp, err := kine.client.Get(ctx,
 							nextKey,
 							clientv3.WithRange(endRange),
 							clientv3.WithLimit(int64(b.N)/10),
 						)
+						b.StopTimer()
 						g.Expect(err).To(BeNil())
 
 						more = resp.More
 						count += len(resp.Kvs)
 						nextKey = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x01"
 					}
-					b.StopTimer()
 					g.Expect(count).To(Equal((b.N + 1) / 2))
-
 					kine.ReportMetrics(b)
 				})
 			})

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -210,6 +210,7 @@ func BenchmarkList(b *testing.B) {
 			b.Run(fmt.Sprintf("%s-%s", backendType, payload.name), func(b *testing.B) {
 				b.Run("all", func(b *testing.B) {
 					g := NewWithT(b)
+					b.StopTimer()
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
@@ -224,15 +225,16 @@ func BenchmarkList(b *testing.B) {
 					kine.ResetMetrics()
 					b.StartTimer()
 					resp, err := kine.client.Get(ctx, "key/", clientv3.WithPrefix())
-
+					b.StopTimer()
 					g.Expect(err).To(BeNil())
 					g.Expect(resp.Kvs).To(HaveLen((b.N + 1) / 2))
-					b.StopTimer()
+
 					kine.ReportMetrics(b)
 				})
 
 				b.Run("pagination", func(b *testing.B) {
 					g := NewWithT(b)
+					b.StopTimer()
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
@@ -261,9 +263,9 @@ func BenchmarkList(b *testing.B) {
 						count += len(resp.Kvs)
 						nextKey = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x01"
 					}
-
-					g.Expect(count).To(Equal((b.N + 1) / 2))
 					b.StopTimer()
+					g.Expect(count).To(Equal((b.N + 1) / 2))
+
 					kine.ReportMetrics(b)
 				})
 			})

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -209,7 +209,6 @@ func BenchmarkList(b *testing.B) {
 		for _, payload := range payloads {
 			b.Run(fmt.Sprintf("%s-%s", backendType, payload.name), func(b *testing.B) {
 				b.Run("all", func(b *testing.B) {
-					b.StopTimer()
 					g := NewWithT(b)
 
 					ctx, cancel := context.WithCancel(context.Background())
@@ -228,11 +227,11 @@ func BenchmarkList(b *testing.B) {
 
 					g.Expect(err).To(BeNil())
 					g.Expect(resp.Kvs).To(HaveLen((b.N + 1) / 2))
+					b.StopTimer()
 					kine.ReportMetrics(b)
 				})
 
 				b.Run("pagination", func(b *testing.B) {
-					b.StopTimer()
 					g := NewWithT(b)
 
 					ctx, cancel := context.WithCancel(context.Background())
@@ -264,6 +263,7 @@ func BenchmarkList(b *testing.B) {
 					}
 
 					g.Expect(count).To(Equal((b.N + 1) / 2))
+					b.StopTimer()
 					kine.ReportMetrics(b)
 				})
 			})

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -74,6 +74,7 @@ func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			g := NewWithT(b)
+			b.StopTimer()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -73,7 +73,6 @@ func TestUpdate(t *testing.T) {
 func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
 			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -87,6 +86,7 @@ func BenchmarkUpdate(b *testing.B) {
 				value := fmt.Sprintf("value-%d", i)
 				lastModRev = updateRev(ctx, g, kine.client, "benchKey", lastModRev, value)
 			}
+			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -82,24 +82,15 @@ func BenchmarkUpdate(b *testing.B) {
 			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
 
 			kine.ResetMetrics()
-			b.StartTimer()
 			for i, lastModRev := 0, int64(0); i < b.N; i++ {
 				value := fmt.Sprintf("value-%d", i)
+				b.StartTimer()
 				lastModRev = updateRev(ctx, g, kine.client, "benchKey", lastModRev, value)
+				b.StopTimer()
 			}
-			b.StopTimer()
 			kine.ReportMetrics(b)
 		})
 	}
-}
-
-func updateKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
-	resp, err := client.Get(ctx, key, clientv3.WithRange(""))
-
-	g.Expect(err).To(BeNil())
-	g.Expect(resp.Kvs).To(HaveLen(1))
-
-	updateRev(ctx, g, client, key, resp.Kvs[0].ModRevision, value)
 }
 
 func updateRev(ctx context.Context, g Gomega, client *clientv3.Client, key string, revision int64, value string) int64 {

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -73,8 +73,8 @@ func TestUpdate(t *testing.T) {
 func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
-			g := NewWithT(b)
 			b.StopTimer()
+			g := NewWithT(b)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()


### PR DESCRIPTION
## DRAFT
Reduces time counting towards validation or other things and reduces the time to the actual query that we would like to benchmark.
Also removes a piece of dead code.