### PR TITLE
Code cleanup remove lease test and dead code

### DIFF
--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -79,30 +79,3 @@ func TestLease(t *testing.T) {
 		})
 	}
 }
-
-// BenchmarkLease is a benchmark for the lease operation.
-func BenchmarkLease(b *testing.B) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
-		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
-			g := NewWithT(b)
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
-
-			kine.ResetMetrics()
-			b.StartTimer()
-			for i := 0; i < b.N; i++ {
-				var ttl int64 = int64(i + 1)
-				resp, err := kine.client.Lease.Grant(ctx, ttl)
-
-				g.Expect(err).To(BeNil())
-				g.Expect(resp.ID).To(Equal(clientv3.LeaseID(ttl)))
-				g.Expect(resp.TTL).To(Equal(ttl))
-			}
-			kine.ReportMetrics(b)
-		})
-	}
-}

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -92,15 +92,6 @@ func BenchmarkUpdate(b *testing.B) {
 	}
 }
 
-func updateKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {
-	resp, err := client.Get(ctx, key, clientv3.WithRange(""))
-
-	g.Expect(err).To(BeNil())
-	g.Expect(resp.Kvs).To(HaveLen(1))
-
-	updateRev(ctx, g, client, key, resp.Kvs[0].ModRevision, value)
-}
-
 func updateRev(ctx context.Context, g Gomega, client *clientv3.Client, key string, revision int64, value string) int64 {
 	resp, err := client.Txn(ctx).
 		If(clientv3.Compare(clientv3.ModRevision(key), "=", revision)).


### PR DESCRIPTION
## Description 

Note that calling lease grant doesn't do anything but return a response to k8s, leases and ttl are handled by a long running go routine in the kine layer: [pkg/kine/logstructured/logstructured.go](https://github.com/canonical/k8s-dqlite/blob/master/pkg/kine/logstructured/logstructured.go#L383).
Removing the benchmark test because it is not measuring any lease performance.

The function `updateKey` is not used and can be removed.
