### PR TITLE
Update Query

### DIFF
--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -554,8 +554,7 @@ func (d *Generic) Update(ctx context.Context, key string, value []byte, preRev, 
 	if insertCount, err := result.RowsAffected(); err != nil {
 		return 0, err
 	} else if insertCount == 0 {
-		return 0, server.ErrKeyExists
-		// FIXME: Wrong Error
+		return 0, server.ErrRevNotFound
 	}
 	return result.LastInsertId()
 }

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -320,13 +320,13 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				0 AS created,
 				0 AS deleted,
 				create_revision,
-				MAX(id) AS prev_revision,
+				id AS prev_revision,
 				? AS lease,
 				? AS value,
 				value AS old_value
-			FROM kine WHERE name = ?
-			GROUP BY name
-			HAVING deleted = 0 AND id = ?`, paramCharacter, numbered),
+			FROM kine WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
+    			AND deleted = 0
+    			AND id = ?`, paramCharacter, numbered),
 
 		FillSQL: q(`INSERT INTO kine(id, name, created, deleted, create_revision, prev_revision, lease, value, old_value)
 			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`, paramCharacter, numbered),

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -320,16 +320,12 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				0 AS created,
 				0 AS deleted,
 				create_revision,
-				id AS prev_revision,
+				MAX(id) AS prev_revision,
 				? AS lease,
 				? AS value,
 				value AS old_value
-			 FROM(
-				SELECT MAX(id) AS id, deleted, create_revision, prev_revision, value
-				FROM kine
-				WHERE name = ?
-			) maxkv
-			WHERE maxkv.deleted = 0 AND maxkv.id = ?`, paramCharacter, numbered),
+			FROM kine WHERE name = ?
+			HAVING deleted = 0 AND id = ?`, paramCharacter, numbered),
 
 		FillSQL: q(`INSERT INTO kine(id, name, created, deleted, create_revision, prev_revision, lease, value, old_value)
 			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`, paramCharacter, numbered),

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -320,7 +320,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				0 AS created,
 				0 AS deleted,
 				create_revision,
-				prev_revision,
+				id AS prev_revision,
 				? AS lease,
 				? AS value,
 				value AS old_value

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -325,6 +325,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				? AS value,
 				value AS old_value
 			FROM kine WHERE name = ?
+			GROUP BY name
 			HAVING deleted = 0 AND id = ?`, paramCharacter, numbered),
 
 		FillSQL: q(`INSERT INTO kine(id, name, created, deleted, create_revision, prev_revision, lease, value, old_value)

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -67,6 +67,7 @@ type Dialect interface {
 	After(ctx context.Context, rev, limit int64) (*sql.Rows, error)
 	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (int64, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
+	Update(ctx context.Context, key string, value []byte, prevRev, lease int64) (int64, error)
 	DeleteRevision(ctx context.Context, revision int64) error
 	GetCompactRevision(ctx context.Context) (int64, int64, error)
 	Compact(ctx context.Context, revision int64) error
@@ -563,6 +564,29 @@ func (s *SQLLog) Create(ctx context.Context, key string, value []byte, lease int
 	default:
 	}
 	return rev, nil
+}
+
+func (s *SQLLog) Update(ctx context.Context, key string, value []byte, prevRev, lease int64) (rev int64, err error) {
+	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Update", otelName))
+	defer func() {
+		span.RecordError(err)
+		span.SetAttributes(attribute.Int64("revision", rev))
+		span.End()
+	}()
+	span.SetAttributes(attribute.String("key", key),
+		attribute.Int64("prevRev", prevRev),
+	)
+
+	rev, err = s.d.Update(ctx, key, value, prevRev, lease)
+	if err != nil {
+		return 0, err
+	}
+
+	select {
+	case s.notify <- rev:
+	default:
+	}
+	return rev, err
 }
 
 func scan(rows *sql.Rows, event *server.Event) error {

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -2,13 +2,15 @@ package server
 
 import (
 	"context"
+	"errors"
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 var (
-	ErrKeyExists = rpctypes.ErrGRPCDuplicateKey
-	ErrCompacted = rpctypes.ErrGRPCCompacted
+	ErrKeyExists   = rpctypes.ErrGRPCDuplicateKey
+	ErrCompacted   = rpctypes.ErrGRPCCompacted
+	ErrRevNotFound = errors.New("revision not found")
 )
 
 type Backend interface {

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -2,15 +2,13 @@ package server
 
 import (
 	"context"
-	"errors"
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 var (
-	ErrKeyExists   = rpctypes.ErrGRPCDuplicateKey
-	ErrCompacted   = rpctypes.ErrGRPCCompacted
-	ErrRevNotFound = errors.New("revision not found")
+	ErrKeyExists = rpctypes.ErrGRPCDuplicateKey
+	ErrCompacted = rpctypes.ErrGRPCCompacted
 )
 
 type Backend interface {
@@ -21,7 +19,7 @@ type Backend interface {
 	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
-	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
+	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, bool, error)
 	Watch(ctx context.Context, key string, revision int64) <-chan []*Event
 	DbSize(ctx context.Context) (int64, error)
 	DoCompact(ctx context.Context) error

--- a/pkg/kine/server/update.go
+++ b/pkg/kine/server/update.go
@@ -47,8 +47,10 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 	if rev == 0 {
 		rev, err = l.backend.Create(ctx, key, value, lease)
 		if err == ErrKeyExists {
-			updated = false
-			err = nil
+			return &etcdserverpb.TxnResponse{
+				Header:    txnHeader(rev),
+				Succeeded: false,
+			}, nil
 		} else {
 			updated = true
 		}

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -104,7 +104,7 @@ func assertMissingKey(ctx context.Context, g Gomega, client *clientv3.Client, ke
 	g.Expect(resp.Kvs).To(HaveLen(0))
 }
 
-func deleteKey(ctx context.Context, g Gomega, client *clientv3.Client, key string) {
+func deleteKey(ctx context.Context, g Gomega, client *clientv3.Client, key string) int64 {
 	// The Get before the Delete is to trick kine to accept the transaction
 	resp, err := client.Txn(ctx).
 		Then(clientv3.OpGet(key), clientv3.OpDelete(key)).
@@ -112,6 +112,7 @@ func deleteKey(ctx context.Context, g Gomega, client *clientv3.Client, key strin
 
 	g.Expect(err).To(BeNil())
 	g.Expect(resp.Succeeded).To(BeTrue())
+	return resp.Header.Revision
 }
 
 func assertKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, value string) {

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -218,7 +218,7 @@ func BenchmarkList(b *testing.B) {
 					kine := newKineServer(ctx, b, &kineOptions{
 						backendType: backendType,
 						setup: func(ctx context.Context, tx *sql.Tx) error {
-							return setup(ctx, tx, payload.size, 100000)
+							return setup(ctx, tx, payload.size, b.N)
 						},
 					})
 

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -218,7 +218,7 @@ func BenchmarkList(b *testing.B) {
 					kine := newKineServer(ctx, b, &kineOptions{
 						backendType: backendType,
 						setup: func(ctx context.Context, tx *sql.Tx) error {
-							return setup(ctx, tx, payload.size, b.N)
+							return setup(ctx, tx, payload.size, 100000)
 						},
 					})
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -67,6 +67,7 @@ func TestUpdate(t *testing.T) {
 				g.Expect(resp.Responses).To(HaveLen(1))
 				g.Expect(resp.Responses[0].GetResponseRange()).ToNot(BeNil())
 			})
+
 			t.Run("UpdatedDeletedKeyFails", func(t *testing.T) {
 				g := NewWithT(t)
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -27,7 +27,7 @@ func TestUpdate(t *testing.T) {
 				updateRev(ctx, g, kine.client, "updateExistingKey", lastModRev, "testValue2")
 
 				resp, err := kine.client.Get(ctx, "updateExistingKey", clientv3.WithRange(""))
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Kvs).To(HaveLen(1))
 				g.Expect(resp.Kvs[0].Key).To(Equal([]byte("updateExistingKey")))
 				g.Expect(resp.Kvs[0].Value).To(Equal([]byte("testValue2")))
@@ -45,7 +45,7 @@ func TestUpdate(t *testing.T) {
 					Else(clientv3.OpGet("createExistingKey", clientv3.WithRange(""))).
 					Commit()
 
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Succeeded).To(BeFalse())
 			})
 
@@ -62,7 +62,7 @@ func TestUpdate(t *testing.T) {
 					Else(clientv3.OpGet("updateOldRevKey", clientv3.WithRange(""))).
 					Commit()
 
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Succeeded).To(BeFalse())
 				g.Expect(resp.Responses).To(HaveLen(1))
 				g.Expect(resp.Responses[0].GetResponseRange()).ToNot(BeNil())
@@ -77,7 +77,7 @@ func TestUpdate(t *testing.T) {
 					Else(clientv3.OpGet("updateNotExistingKey", clientv3.WithRange(""))).
 					Commit()
 
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Succeeded).To(BeFalse())
 				g.Expect(resp.Responses).To(HaveLen(1))
 				g.Expect(resp.Responses[0].GetResponseRange()).ToNot(BeNil())
@@ -95,7 +95,7 @@ func TestUpdate(t *testing.T) {
 					Else(clientv3.OpGet("updateDeletedKey", clientv3.WithRange(""))).
 					Commit()
 
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Succeeded).To(BeFalse())
 				g.Expect(resp.Responses).To(HaveLen(1))
 				g.Expect(resp.Responses[0].GetResponseRange()).ToNot(BeNil())
@@ -148,7 +148,7 @@ func updateRev(ctx context.Context, g Gomega, client *clientv3.Client, key strin
 	}
 	resp, err := txn.Commit()
 
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(resp.Succeeded).To(BeTrue())
 
 	return resp.Responses[0].GetResponsePut().Header.Revision


### PR DESCRIPTION
## Description
This PR creates a separate query for update instead of calling the Append method which does an insert. 
Upon a successful update the response returns the revision of the key.
An unsuccessful update can have the following reasons:
- Key does not exist
- Key is deleted
- We are asked to update a previous revision of the key
In those cases we try to get the latest revision of the key and return it in the response.

Note: We no longer return preRev with a successful update response this was only needed on migration from etcd v2 to etcd v3.

## Performance
This Query can be optimized when we are able to do a schema change and can put an index on deleted.