### PR TITLE
Add concurrency to create/update/insert benchmarks

### DIFF
--- a/test/create_test.go
+++ b/test/create_test.go
@@ -60,10 +60,9 @@ func BenchmarkCreate(b *testing.B) {
 				kine.ResetMetrics()
 				b.StartTimer()
 				wg.Add(workers)
-				for worker := 0; worker < workers-1; worker++ {
+				for worker := 0; worker < workers; worker++ {
 					go run(worker)
 				}
-				run(workers - 1)
 				wg.Wait()
 				kine.ReportMetrics(b)
 			})

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -39,7 +39,7 @@ func TestCreate(t *testing.T) {
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%s-%d", backendType, workers), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s-workers(%d)", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -39,7 +39,7 @@ func TestCreate(t *testing.T) {
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%s-workers(%d)", backendType, workers), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%d-workers/%s", workers, backendType), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
@@ -37,24 +38,36 @@ func TestCreate(t *testing.T) {
 // BenchmarkCreate is a benchmark for the Create operation.
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
-		b.Run(backendType, func(b *testing.B) {
-			b.StopTimer()
-			g := NewWithT(b)
+		for _, workers := range []int{1, 2, 4, 8, 16} {
+			b.Run(fmt.Sprintf("%s-%d", backendType, workers), func(b *testing.B) {
+				b.StopTimer()
+				g := NewWithT(b)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-			kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
+				kine := newKineServer(ctx, b, &kineOptions{backendType: backendType})
+				wg := &sync.WaitGroup{}
+				run := func(start int) {
+					defer wg.Done()
+					for i := start; i < b.N; i += workers {
+						key := fmt.Sprintf("key-%d", i)
+						value := fmt.Sprintf("value-%d", i)
+						createKey(ctx, g, kine.client, key, value)
+					}
+				}
 
-			kine.ResetMetrics()
-			b.StartTimer()
-			for i := 0; i < b.N; i++ {
-				key := fmt.Sprintf("key-%d", i)
-				value := fmt.Sprintf("value-%d", i)
-				createKey(ctx, g, kine.client, key, value)
-			}
-			kine.ReportMetrics(b)
-		})
+				kine.ResetMetrics()
+				b.StartTimer()
+				wg.Add(workers)
+				for worker := 0; worker < workers-1; worker++ {
+					go run(worker)
+				}
+				run(workers - 1)
+				wg.Wait()
+				kine.ReportMetrics(b)
+			})
+		}
 	}
 }
 

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -59,7 +59,7 @@ func TestDelete(t *testing.T) {
 func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%s-%d", backendType, workers), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s-workers(%d)", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -87,10 +87,9 @@ func BenchmarkDelete(b *testing.B) {
 				kine.ResetMetrics()
 				b.StartTimer()
 				wg.Add(workers)
-				for worker := 0; worker < workers-1; worker++ {
+				for worker := 0; worker < workers; worker++ {
 					go run(worker)
 				}
-				run(workers - 1)
 				wg.Wait()
 				kine.ReportMetrics(b)
 			})

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -59,7 +59,7 @@ func TestDelete(t *testing.T) {
 func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%s-workers(%d)", backendType, workers), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%d-workers/%s", workers, backendType), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -95,10 +95,9 @@ func BenchmarkUpdate(b *testing.B) {
 				kine.ResetMetrics()
 				b.StartTimer()
 				wg.Add(workers)
-				for worker := 0; worker < workers-1; worker++ {
+				for worker := 0; worker < workers; worker++ {
 					go run(worker)
 				}
-				run(workers - 1)
 				wg.Wait()
 				kine.ReportMetrics(b)
 			})

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -74,7 +74,7 @@ func TestUpdate(t *testing.T) {
 func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%s-%d", backendType, workers), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s-workers(%d)", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -74,7 +74,7 @@ func TestUpdate(t *testing.T) {
 func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%s-workers(%d)", backendType, workers), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%d-workers/%s", workers, backendType), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 


### PR DESCRIPTION
Single threading benchmarking is interesting, but it is also necessary to understand how the system behaves in the face of multiple concurrent clients contenting the database.


This PR adds concurrency to the write path, while keeping operations distinct (i.e. no mixed create/update/delete load). While still a synthetic load, it can be considered "closer to reality".
