### PR TITLE
Rename concurrent tests for create, delete and update

### DIFF
--- a/test/create_test.go
+++ b/test/create_test.go
@@ -39,7 +39,7 @@ func TestCreate(t *testing.T) {
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%d-workers/%s", workers, backendType), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -59,7 +59,7 @@ func TestDelete(t *testing.T) {
 func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%d-workers/%s", workers, backendType), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -108,7 +108,7 @@ func TestUpdate(t *testing.T) {
 func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
 		for _, workers := range []int{1, 2, 4, 8, 16} {
-			b.Run(fmt.Sprintf("%d-workers/%s", workers, backendType), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)
 


### PR DESCRIPTION
This PR renames the subtests that use multiple workers so that they can be easily filtered by backend type.

As of now, doing `go test -run ^$ -branch "./dqlite" does not select those tests. This PR makes sure that they are all part of the same cathegory.