### PR TITLE
Use constant concatenation for otel span names

### DIFF
--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -351,7 +351,8 @@ func getPrefixRange(prefix string) (start, end string) {
 }
 
 func (d *Generic) query(ctx context.Context, txName, query string, args ...interface{}) (rows *sql.Rows, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.query", otelName))
+	const spanName = otelName + ".query"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -394,7 +395,8 @@ func (d *Generic) query(ctx context.Context, txName, query string, args ...inter
 }
 
 func (d *Generic) execute(ctx context.Context, txName, query string, args ...interface{}) (result sql.Result, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.execute", otelName))
+	const spanName = otelName + ".execute"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -502,7 +504,8 @@ func (d *Generic) Count(ctx context.Context, prefix, startKey string, revision i
 }
 
 func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int64) (rev int64, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
+	const spanName = otelName + ".Create"
+	ctx, span := otelTracer.Start(ctx, spanName)
 
 	defer func() {
 		if err != nil {
@@ -532,7 +535,8 @@ func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int6
 	return result.LastInsertId()
 }
 func (d *Generic) Update(ctx context.Context, key string, value []byte, preRev, ttl int64) (rev int64, updated bool, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Update", otelName))
+	const spanName = otelName + ".Update"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		if err != nil {
 			if d.TranslateErr != nil {
@@ -562,7 +566,8 @@ func (d *Generic) Update(ctx context.Context, key string, value []byte, preRev, 
 // a compacted error.
 func (d *Generic) Compact(ctx context.Context, revision int64) (err error) {
 	compactCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Compact", otelName))
+	const spanName = otelName + ".Compact"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -592,7 +597,8 @@ func (d *Generic) Compact(ctx context.Context, revision int64) (err error) {
 }
 
 func (d *Generic) tryCompact(ctx context.Context, start, end int64) (err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.tryCompact", otelName))
+	const spanName = otelName + ".tryCompact"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -648,7 +654,8 @@ func (d *Generic) tryCompact(ctx context.Context, start, end int64) (err error) 
 
 func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) {
 	getCompactRevCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.get_compact_revision", otelName))
+	const spanName = otelName + ".get_compact_revision"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	var compact, target sql.NullInt64
 	start := time.Now()
 	var err error
@@ -688,7 +695,8 @@ func (d *Generic) GetCompactRevision(ctx context.Context) (int64, int64, error) 
 func (d *Generic) DeleteRevision(ctx context.Context, revision int64) error {
 	var err error
 	deleteRevCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.delete_revision", otelName))
+	const spanName = otelName + ".delete_revision"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -738,7 +746,8 @@ func (d *Generic) CurrentRevision(ctx context.Context) (int64, error) {
 	var err error
 
 	currentRevCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.current_revision", otelName))
+	const spanName = otelName + ".current_revision"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/logstructured/logstructured.go
+++ b/pkg/kine/logstructured/logstructured.go
@@ -73,7 +73,8 @@ func (l *LogStructured) Wait() {
 }
 
 func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (revRet int64, kvRet *server.KeyValue, errRet error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Get", otelName))
+	const spanName = otelName + ".Get"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	span.SetAttributes(
 		attribute.String("key", key),
 		attribute.String("rangeEnd", rangeEnd),
@@ -97,7 +98,8 @@ func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, re
 
 func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, revision int64, includeDeletes bool) (int64, *server.Event, error) {
 	var err error
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.get", otelName))
+	const spanName = otelName + ".get"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -138,7 +140,8 @@ func (l *LogStructured) adjustRevision(ctx context.Context, rev *int64) {
 }
 
 func (l *LogStructured) Create(ctx context.Context, key string, value []byte, lease int64) (rev int64, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
+	const spanName = otelName + ".Create"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer span.End()
 	rev, err = l.log.Create(ctx, key, value, lease)
 	logrus.Debugf("CREATE %s, size=%d, lease=%d => rev=%d, err=%v", key, len(value), lease, rev, err)
@@ -146,7 +149,8 @@ func (l *LogStructured) Create(ctx context.Context, key string, value []byte, le
 }
 
 func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) (revRet int64, kvRet *server.KeyValue, deletedRet bool, errRet error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Delete", otelName))
+	const spanName = otelName + ".Delete"
+	ctx, span := otelTracer.Start(ctx, spanName)
 
 	defer func() {
 		l.adjustRevision(ctx, &revRet)
@@ -204,7 +208,8 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 }
 
 func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit, revision int64) (revRet int64, kvRet []*server.KeyValue, errRet error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.List", otelName))
+	const spanName = otelName + ".List"
+	ctx, span := otelTracer.Start(ctx, spanName)
 
 	defer func() {
 		logrus.Debugf("LIST %s, start=%s, limit=%d, rev=%d => rev=%d, kvs=%d, err=%v", prefix, startKey, limit, revision, revRet, len(kvRet), errRet)
@@ -246,7 +251,8 @@ func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit
 }
 
 func (l *LogStructured) Count(ctx context.Context, prefix, startKey string, revision int64) (revRet int64, count int64, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Count", otelName))
+	const spanName = otelName + ".Count"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		logrus.Debugf("COUNT prefix=%s startKey=%s => rev=%d, count=%d, err=%v", prefix, startKey, revRet, count, err)
 		span.SetAttributes(
@@ -277,7 +283,8 @@ func (l *LogStructured) Count(ctx context.Context, prefix, startKey string, revi
 }
 
 func (l *LogStructured) Update(ctx context.Context, key string, value []byte, revision, lease int64) (revRet int64, updateRet bool, errRet error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Update", otelName))
+	const spanName = otelName + ".Update"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		logrus.Debugf("UPDATE %s, value=%d, rev=%d, lease=%v => rev=%d, updated=%v, err=%v", key, len(value), revision, lease, revRet, updateRet, errRet)
 		span.SetAttributes(
@@ -360,7 +367,8 @@ func (l *LogStructured) ttl(ctx context.Context) {
 
 func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64) <-chan []*server.Event {
 	logrus.Debugf("WATCH %s, revision=%d", prefix, revision)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Watch", otelName))
+	const spanName = otelName + ".Watch"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer span.End()
 	span.SetAttributes(
 		attribute.String("prefix", prefix),

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -143,7 +143,8 @@ func (s *SQLLog) compactStart(ctx context.Context) error {
 // DoCompact makes a single compaction run when called. It is intended to be called
 // from test functions that have access to the backend.
 func (s *SQLLog) DoCompact(ctx context.Context) (err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.DoCompact", otelName))
+	const spanName = otelName + ".DoCompact"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -188,7 +189,8 @@ func (s *SQLLog) CurrentRevision(ctx context.Context) (int64, error) {
 
 func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64) (int64, []*server.Event, error) {
 	var err error
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.After", otelName))
+	const spanName = otelName + ".After"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -226,7 +228,8 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 		rows *sql.Rows
 		err  error
 	)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.List", otelName))
+	const spanName = otelName + ".List"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -482,7 +485,8 @@ func canSkipRevision(rev, skip int64, skipTime time.Time) bool {
 
 func (s *SQLLog) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error) {
 	var err error
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Count", otelName))
+	const spanName = otelName + ".Count"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -501,7 +505,8 @@ func (s *SQLLog) Count(ctx context.Context, prefix, startKey string, revision in
 
 func (s *SQLLog) Append(ctx context.Context, event *server.Event) (int64, error) {
 	var err error
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Append", otelName))
+	const spanName = otelName + ".Append"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -534,7 +539,8 @@ func (s *SQLLog) Append(ctx context.Context, event *server.Event) (int64, error)
 }
 
 func (s *SQLLog) Create(ctx context.Context, key string, value []byte, lease int64) (rev int64, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
+	const spanName = otelName + ".Create"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.SetAttributes(attribute.Int64("revision", rev))
@@ -597,7 +603,8 @@ func scan(rows *sql.Rows, event *server.Event) error {
 
 func (s *SQLLog) DbSize(ctx context.Context) (int64, error) {
 	var err error
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.DbSize", otelName))
+	const spanName = otelName + ".DbSize"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/prepared/db.go
+++ b/pkg/kine/prepared/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -36,7 +35,8 @@ func New(db *sql.DB) *DB {
 func (db *DB) Underlying() *sql.DB { return db.underlying }
 
 func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.ExecContext", otelName))
+	const spanName = otelName + ".ExecContext"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -50,7 +50,8 @@ func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (resul
 }
 
 func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.QueryContext", otelName))
+	const spanName = otelName + ".QueryContext"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()
@@ -84,7 +85,8 @@ func (db *DB) Close() error {
 }
 
 func (db *DB) prepare(ctx context.Context, query string) (stmt *sql.Stmt, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.prepare", otelName))
+	const spanName = otelName + ".prepare"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/server/create.go
+++ b/pkg/kine/server/create.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.opentelemetry.io/otel/attribute"
@@ -24,7 +23,8 @@ func isCreate(txn *etcdserverpb.TxnRequest) *etcdserverpb.PutRequest {
 func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest, txn *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
 	var err error
 	createCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.create", otelName))
+	const spanName = otelName + ".create"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.opentelemetry.io/otel/attribute"
@@ -32,7 +31,8 @@ func isDelete(txn *etcdserverpb.TxnRequest) (int64, string, bool) {
 func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) (*etcdserverpb.TxnResponse, error) {
 	var err error
 	deleteCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.delete", otelName))
+	const spanName = otelName + ".delete"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/server/get.go
+++ b/pkg/kine/server/get.go
@@ -11,7 +11,8 @@ import (
 func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {
 	var err error
 	getCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.get", otelName))
+	const spanName = otelName + ".get"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/server/limited.go
+++ b/pkg/kine/server/limited.go
@@ -12,7 +12,8 @@ type LimitedServer struct {
 }
 
 func (l *LimitedServer) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Range", otelName))
+	const spanName = otelName + ".Range"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer span.End()
 	if len(r.RangeEnd) == 0 {
 		return l.get(ctx, r)

--- a/pkg/kine/server/list.go
+++ b/pkg/kine/server/list.go
@@ -14,7 +14,8 @@ import (
 func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {
 	var err error
 	listCnt.Add(ctx, 1)
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.list", otelName))
+	const spanName = otelName + ".list"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()

--- a/pkg/kine/server/update.go
+++ b/pkg/kine/server/update.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.opentelemetry.io/otel/attribute"
@@ -33,7 +32,8 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 	)
 	updateCnt.Add(ctx, 1)
 
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.update", otelName))
+	const spanName = otelName + ".update"
+	ctx, span := otelTracer.Start(ctx, spanName)
 	defer func() {
 		span.RecordError(err)
 		span.End()


### PR DESCRIPTION
This is an experimental PR to understand the impact of small concatenation of strings in the hot path. 

I expect this to be more relevant to one-shot queries like GET/CREATE/DELETE/UPDATE rather than in others like LIST or COMPACT.

In general, reducing pressure on the GC is a good thing.