### PR TITLE
Improve rows parsing logic

### DIFF
--- a/pkg/kine/logstructured/sqllog/rows_scanner.go
+++ b/pkg/kine/logstructured/sqllog/rows_scanner.go
@@ -1,0 +1,71 @@
+package sqllog
+
+import (
+	"database/sql"
+
+	"github.com/canonical/k8s-dqlite/pkg/kine/server"
+)
+
+// rowsScanner is used as an iterim object to avoid
+// allocation during rows iteration. It is effective
+// mostly when returning a big amount of rows.
+type rowsScanner struct {
+	currentRev int64
+	key        string
+	create     bool
+	delete     bool
+	createRev  int64
+	prevRev    int64
+	lease      int64
+	value      []byte
+	prevValue  []byte
+}
+
+func (rs *rowsScanner) scan(rows *sql.Rows) (server.Event, error) {
+	err := rows.Scan(
+		&rs.currentRev,
+		&rs.key,
+		&rs.create,
+		&rs.delete,
+		&rs.createRev,
+		&rs.prevRev,
+		&rs.lease,
+		&rs.value,
+		&rs.prevValue,
+	)
+	if err != nil {
+		return server.Event{}, err
+	}
+
+	if rs.create {
+		return server.Event{
+			Create: true,
+			Delete: false,
+			KV: &server.KeyValue{
+				ModRevision:    rs.currentRev,
+				Key:            rs.key,
+				CreateRevision: rs.createRev,
+				Lease:          rs.lease,
+				Value:          rs.value,
+			},
+		}, nil
+	} else {
+		return server.Event{
+			Create: false,
+			Delete: rs.delete,
+			KV: &server.KeyValue{
+				ModRevision:    rs.currentRev,
+				Key:            rs.key,
+				CreateRevision: rs.createRev,
+				Lease:          rs.lease,
+				Value:          rs.value,
+			},
+			PrevKV: &server.KeyValue{
+				ModRevision:    rs.prevRev,
+				Key:            rs.key,
+				CreateRevision: rs.createRev,
+				Value:          rs.prevValue,
+			},
+		}, nil
+	}
+}

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -20,7 +20,7 @@ type Backend interface {
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, bool, error)
-	Watch(ctx context.Context, key string, revision int64) <-chan []*Event
+	Watch(ctx context.Context, key string, revision int64) <-chan []Event
 	DbSize(ctx context.Context) (int64, error)
 	DoCompact(ctx context.Context) error
 }

--- a/pkg/kine/server/watch.go
+++ b/pkg/kine/server/watch.go
@@ -77,15 +77,15 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 			}
 
 			if logrus.IsLevelEnabled(logrus.DebugLevel) {
-				for _, event := range events {
-					logrus.Debugf("WATCH READ id=%d, key=%s, revision=%d", id, event.KV.Key, event.KV.ModRevision)
+				for i := range events {
+					logrus.Debugf("WATCH READ id=%d, key=%s, revision=%d", id, events[i].KV.Key, events[i].KV.ModRevision)
 				}
 			}
 
 			if err := w.server.Send(&etcdserverpb.WatchResponse{
 				Header:  txnHeader(events[len(events)-1].KV.ModRevision),
 				WatchId: id,
-				Events:  toEvents(events...),
+				Events:  toEvents(events),
 			}); err != nil {
 				w.Cancel(id, err)
 				continue
@@ -96,10 +96,10 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 	}()
 }
 
-func toEvents(events ...*Event) []*mvccpb.Event {
+func toEvents(events []Event) []*mvccpb.Event {
 	ret := make([]*mvccpb.Event, 0, len(events))
-	for _, e := range events {
-		ret = append(ret, toEvent(e))
+	for i := range events {
+		ret = append(ret, toEvent(&events[i]))
 	}
 	return ret
 }


### PR DESCRIPTION
Rows parsing is the central logic that iterates over the result of a query and creates domain values.

This PR tweaks the way this is done by:
 - using values instead of pointers as we are returning slices of small structs
 - allocating only when necessary

Hopefully this will reduce slightly the memory footprint and (more importantly) will reduce the allocation count, reducing pressure on the GC.