### PR TITLE
Delete Query

### DIFF
--- a/pkg/kine/drivers/generic/admission.go
+++ b/pkg/kine/drivers/generic/admission.go
@@ -28,6 +28,8 @@ const (
 var writeQueries = map[string]bool{
 	"update_compact_sql":        true,
 	"delete_sql":                true,
+	"update_sql":                true,
+	"delete_rev_sql":            true,
 	"fill_sql":                  true,
 	"insert_last_insert_id_sql": true,
 	"insert_sql":                true,

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -309,7 +309,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				value AS old_value
 			FROM kine WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
     			AND deleted = 0
-				AND (id = ? OR ? = 0)`, paramCharacter, numbered),
+				AND id = ?`, paramCharacter, numbered),
 
 		CreateSQL: q(`
 			INSERT INTO kine(name, created, deleted, create_revision, prev_revision, lease, value, old_value)
@@ -588,7 +588,7 @@ func (d *Generic) Delete(ctx context.Context, key string, revision int64) (rev i
 	}()
 	span.SetAttributes(attribute.String("key", key))
 
-	result, err := d.execute(ctx, "delete_sql", d.DeleteSQL, key, revision, revision)
+	result, err := d.execute(ctx, "delete_sql", d.DeleteSQL, key, revision)
 	if err != nil {
 		logrus.WithError(err).Error("failed to delete key")
 		return 0, false, err

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -309,7 +309,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				value AS old_value
 			FROM kine WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
     			AND deleted = 0
-    			AND id = ?`, paramCharacter, numbered),
+				AND (id = ? OR ? = 0)`, paramCharacter, numbered),
 
 		CreateSQL: q(`
 			INSERT INTO kine(name, created, deleted, create_revision, prev_revision, lease, value, old_value)
@@ -588,7 +588,7 @@ func (d *Generic) Delete(ctx context.Context, key string, revision int64) (rev i
 	}()
 	span.SetAttributes(attribute.String("key", key))
 
-	result, err := d.execute(ctx, "delete_sql", d.DeleteSQL, key, revision)
+	result, err := d.execute(ctx, "delete_sql", d.DeleteSQL, key, revision, revision)
 	if err != nil {
 		logrus.WithError(err).Error("failed to delete key")
 		return 0, false, err

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -302,7 +302,10 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				name,
 				0 AS created,
 				1 AS deleted,
-				create_revision,
+				CASE 
+					WHEN kine.created THEN id
+					ELSE create_revision
+				END AS create_revision,
 				id AS prev_revision,
 				lease,
 				NULL AS value,

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -305,7 +305,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				create_revision,
 				id AS prev_revision,
 				lease,
-				value,
+				NULL AS value,
 				value AS old_value
 			FROM kine WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
     			AND deleted = 0

--- a/pkg/kine/logstructured/logstructured.go
+++ b/pkg/kine/logstructured/logstructured.go
@@ -31,6 +31,7 @@ type Log interface {
 	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeletes bool) (int64, []*server.Event, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (revRet int64, updateRet bool, errRet error)
+	Delete(ctx context.Context, key string, revision int64) (revRet int64, deleted bool, errRet error)
 	After(ctx context.Context, prefix string, revision, limit int64) (int64, []*server.Event, error)
 	Watch(ctx context.Context, prefix string) <-chan []*server.Event
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
@@ -138,69 +139,15 @@ func (l *LogStructured) adjustRevision(ctx context.Context, rev *int64) {
 }
 
 func (l *LogStructured) Create(ctx context.Context, key string, value []byte, lease int64) (rev int64, err error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
-	defer span.End()
 	rev, err = l.log.Create(ctx, key, value, lease)
 	logrus.Debugf("CREATE %s, size=%d, lease=%d => rev=%d, err=%v", key, len(value), lease, rev, err)
 	return rev, err
 }
 
-func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) (revRet int64, kvRet *server.KeyValue, deletedRet bool, errRet error) {
-	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Delete", otelName))
-
-	defer func() {
-		l.adjustRevision(ctx, &revRet)
-		logrus.Debugf("DELETE %s, rev=%d => rev=%d, kv=%v, deleted=%v, err=%v", key, revision, revRet, kvRet != nil, deletedRet, errRet)
-		span.SetAttributes(
-			attribute.String("key", key),
-			attribute.Int64("revision", revision),
-			attribute.Int64("adjusted-revision", revRet),
-			attribute.Bool("deleted", deletedRet),
-			attribute.Bool("kv-found", kvRet != nil),
-		)
-		span.RecordError(errRet)
-		span.End()
-	}()
-
-	rev, event, err := l.get(ctx, key, "", 1, 0, true)
-	if err != nil {
-		span.RecordError(err)
-		return 0, nil, false, err
-	}
-
-	if event == nil {
-		return rev, nil, true, nil
-	}
-
-	if event.Delete {
-		return rev, event.KV, true, nil
-	}
-
-	if revision != 0 && event.KV.ModRevision != revision {
-		return rev, event.KV, false, nil
-	}
-
-	deleteEvent := &server.Event{
-		Delete: true,
-		KV:     event.KV,
-		PrevKV: event.KV,
-	}
-
-	rev, err = l.log.Append(ctx, deleteEvent)
-	if err != nil {
-		// If error on Append we assume it's a UNIQUE constraint error, so we fetch the latest (if we can)
-		// and return that the delete failed
-		span.AddEvent("Failed to append delete event")
-		span.RecordError(err)
-		latestRev, latestEvent, latestErr := l.get(ctx, key, "", 1, 0, true)
-		if latestErr != nil || latestEvent == nil {
-			span.RecordError(latestErr)
-			span.SetAttributes(attribute.Bool("latest-event-found", latestEvent != nil))
-			return rev, event.KV, false, nil
-		}
-		return latestRev, latestEvent.KV, false, nil
-	}
-	return rev, event.KV, true, err
+func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) (revRet int64, deleted bool, errRet error) {
+	rev, del, err := l.log.Delete(ctx, key, revision)
+	logrus.Debugf("DELETE %s, rev=%d => rev=%d, deleted=%v, err=%v", key, revision, rev, del, err)
+	return rev, del, err
 }
 
 func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit, revision int64) (revRet int64, kvRet []*server.KeyValue, errRet error) {

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -549,8 +549,9 @@ func (s *SQLLog) Delete(ctx context.Context, key string, revision int64) (rev in
 	if err != nil {
 		return 0, false, err
 	}
-
-	s.notifyWatcherPoll(rev)
+	if deleted {
+		s.notifyWatcherPoll(rev)
+	}
 	return rev, deleted, nil
 }
 
@@ -559,8 +560,9 @@ func (s *SQLLog) Update(ctx context.Context, key string, value []byte, prevRev, 
 	if err != nil {
 		return 0, false, err
 	}
-
-	s.notifyWatcherPoll(rev)
+	if updated {
+		s.notifyWatcherPoll(rev)
+	}
 	return rev, updated, nil
 }
 

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -61,9 +61,6 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 		if err != nil {
 			return nil, err
 		}
-		if kv == nil {
-			resp.Succeeded = true
-		}
 		resp.Responses = []*etcdserverpb.ResponseOp{
 			{
 				Response: &etcdserverpb.ResponseOp_ResponseRange{

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -69,6 +69,9 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 		if err != nil {
 			return nil, err
 		}
+		if kv == nil {
+			resp.Succeeded = true
+		}
 		resp.Responses = []*etcdserverpb.ResponseOp{
 			{
 				Response: &etcdserverpb.ResponseOp_ResponseRange{

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -9,14 +9,6 @@ import (
 )
 
 func isDelete(txn *etcdserverpb.TxnRequest) (int64, string, bool) {
-	if len(txn.Compare) == 0 &&
-		len(txn.Failure) == 0 &&
-		len(txn.Success) == 2 &&
-		txn.Success[0].GetRequestRange() != nil &&
-		txn.Success[1].GetRequestDeleteRange() != nil {
-		rng := txn.Success[1].GetRequestDeleteRange()
-		return 0, string(rng.Key), true
-	}
 	if len(txn.Compare) == 1 &&
 		txn.Compare[0].Target == etcdserverpb.Compare_MOD &&
 		txn.Compare[0].Result == etcdserverpb.Compare_EQUAL &&

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -42,41 +42,44 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 		attribute.Int64("revision", revision),
 	)
 
-	rev, kv, ok, err := l.backend.Delete(ctx, key, revision)
+	rev, deleted, err := l.backend.Delete(ctx, key, revision)
 	if err != nil {
 		return nil, err
 	}
-	span.SetAttributes(attribute.Bool("ok", ok))
 
-	if !ok {
-		return &etcdserverpb.TxnResponse{
-			Header: txnHeader(rev),
-			Responses: []*etcdserverpb.ResponseOp{
-				{
-					Response: &etcdserverpb.ResponseOp_ResponseRange{
-						ResponseRange: &etcdserverpb.RangeResponse{
-							Header: txnHeader(rev),
-							Kvs:    toKVs(kv),
-						},
-					},
-				},
-			},
-			Succeeded: false,
-		}, nil
+	span.SetAttributes(attribute.Bool("deleted", deleted))
+
+	resp := &etcdserverpb.TxnResponse{
+		Header:    txnHeader(rev),
+		Succeeded: deleted,
 	}
 
-	return &etcdserverpb.TxnResponse{
-		Header: txnHeader(rev),
-		Responses: []*etcdserverpb.ResponseOp{
+	if deleted {
+		resp.Responses = []*etcdserverpb.ResponseOp{
 			{
 				Response: &etcdserverpb.ResponseOp_ResponseDeleteRange{
 					ResponseDeleteRange: &etcdserverpb.DeleteRangeResponse{
-						Header:  txnHeader(rev),
-						PrevKvs: toKVs(kv),
+						Header: txnHeader(rev),
 					},
 				},
 			},
-		},
-		Succeeded: true,
-	}, nil
+		}
+	} else {
+		rev, kv, err := l.backend.Get(ctx, key, "", 1, rev)
+		if err != nil {
+			return nil, err
+		}
+		resp.Responses = []*etcdserverpb.ResponseOp{
+			{
+				Response: &etcdserverpb.ResponseOp_ResponseRange{
+					ResponseRange: &etcdserverpb.RangeResponse{
+						Header: txnHeader(rev),
+						Kvs:    toKVs(kv),
+					},
+				},
+			},
+		}
+
+	}
+	return resp, nil
 }

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -16,7 +16,7 @@ type Backend interface {
 	Wait()
 	Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (int64, *KeyValue, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
-	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)
+	Delete(ctx context.Context, key string, revision int64) (int64, bool, error)
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, bool, error)

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -34,7 +34,16 @@ func TestDelete(t *testing.T) {
 			// Delete a key that does not exist
 			t.Run("NonExistentKeys", func(t *testing.T) {
 				g := NewWithT(t)
-				deleteKey(ctx, g, kine.client, "missingKey", 1)
+				key := "missing key"
+				rev := 0
+				resp, err := kine.client.Txn(ctx).
+					If(clientv3.Compare(clientv3.ModRevision(key), "=", rev)).
+					Then(clientv3.OpDelete(key)).
+					Else(clientv3.OpGet(key)).
+					Commit()
+
+				g.Expect(err).To(BeNil())
+				g.Expect(resp.Succeeded).To(BeFalse())
 			})
 
 			// Add a key, make sure it exists, then delete it, make sure it got deleted,

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -109,7 +109,6 @@ func assertMissingKey(ctx context.Context, g Gomega, client *clientv3.Client, ke
 }
 
 func deleteKey(ctx context.Context, g Gomega, client *clientv3.Client, key string, revision int64) int64 {
-	// The Get before the Delete is to trick kine to accept the transaction
 	resp, err := client.Txn(ctx).
 		If(clientv3.Compare(clientv3.ModRevision(key), "=", revision)).
 		Then(clientv3.OpDelete(key)).

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -99,8 +99,11 @@ func TestGet(t *testing.T) {
 			t.Run("FailNotFound", func(t *testing.T) {
 				g := NewWithT(t)
 				key := "testKeyFailNotFound"
+				value := "testValue"
+
+				rev := createKey(ctx, g, kine.client, key, value)
 				// Delete key
-				deleteKey(ctx, g, kine.client, key, 0)
+				deleteKey(ctx, g, kine.client, key, rev)
 
 				// Get key
 				resp, err := kine.client.Get(ctx, key, clientv3.WithRange(""))

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -99,7 +99,6 @@ func TestGet(t *testing.T) {
 			t.Run("FailNotFound", func(t *testing.T) {
 				g := NewWithT(t)
 				key := "testKeyFailNotFound"
-
 				// Delete key
 				deleteKey(ctx, g, kine.client, key, 0)
 


### PR DESCRIPTION
# Description

This PR moves the logic for deletion into its own query in generic.

## Query logic for deletion

Happy path:

- The specified revision exists in the database and is not already deleted.
- We insert a row with the revision and mark it as deleted via the column deleted=1.
- the prev value is the last revision's value

Edge cases:

1. The specified revision does not exist in the database.
   - We return success=true, empty KV

2. The specified revision is the latest and is already deleted.
    - We want to return the id of this revision.
    - Return success= false and latest rev

3. The specified revision is not the latest revision.
    - We return the latest rev and kvs, success = false

## Query

This is the delete query:
```sql
INSERT INTO kine(name, created, deleted, create_revision, prev_revision, lease, value, old_value)
    SELECT 
            ? AS name,
            0 AS created,
            1 AS deleted,
            CASE 
	          WHEN kine.created THEN id
	          ELSE create_revision
	    END AS create_revision,
            id AS prev_revision,
            lease,
            NULL AS value,
            value AS old_value
    FROM kine WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
    AND deleted = 0
    AND id = ?;
```

## Optimization for deletion

EXPLAIN QUERY PLAN:

```
QUERY PLAN
|--SEARCH kine USING INTEGER PRIMARY KEY (rowid=?)
`--SCALAR SUBQUERY 1
   `--SEARCH kine USING COVERING INDEX kine_name_index (name=?)
```

Potential optimization with an additional index on deleted.

## Removing unconditional delete

As of Kubernetes v1.15 we do [conditional deletes](https://github.com/kubernetes/kubernetes/blob/v1.15.10/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L195) instead of [unconditional deletes](https://github.com/kubernetes/kubernetes/blob/v1.14.0/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L191). A conditional delete requires the revision of the key to be deleted to match the revision provided in the delete request whereas an unconditional delete does not check for the revision and just deletes what it finds. K8s-dqlite is not used by deployments on v1.14 Kubernetes and can therefore be removed safely.