### PR TITLE
Fix delete benchmark

### DIFF
--- a/test/admission_test.go
+++ b/test/admission_test.go
@@ -35,7 +35,7 @@ func TestAdmissionControl(t *testing.T) {
 					"admission-control-only-write-queries=true",
 				},
 				setup: func(ctx context.Context, tx *sql.Tx) error {
-					if err := insertMany(ctx, tx, "Key", 100, 1000); err != nil {
+					if _, err := insertMany(ctx, tx, "Key", 100, 1000); err != nil {
 						return err
 					}
 					return nil

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -22,13 +22,13 @@ func TestCompaction(t *testing.T) {
 				kine := newKineServer(ctx, t, &kineOptions{
 					backendType: backendType,
 					setup: func(ctx context.Context, tx *sql.Tx) error {
-						if err := insertMany(ctx, tx, "key", 100, 2); err != nil {
+						if _, err := insertMany(ctx, tx, "key", 100, 2); err != nil {
 							return err
 						}
-						if err := updateMany(ctx, tx, "key", 100, 1); err != nil {
+						if _, err := updateMany(ctx, tx, "key", 100, 1); err != nil {
 							return err
 						}
-						if err := deleteMany(ctx, tx, "key", 1); err != nil {
+						if _, err := deleteMany(ctx, tx, "key", 1); err != nil {
 							return err
 						}
 						return nil
@@ -55,13 +55,13 @@ func TestCompaction(t *testing.T) {
 				kine := newKineServer(ctx, t, &kineOptions{
 					backendType: backendType,
 					setup: func(ctx context.Context, tx *sql.Tx) error {
-						if err := insertMany(ctx, tx, "key", 100, 10_000); err != nil {
+						if _, err := insertMany(ctx, tx, "key", 100, 10_000); err != nil {
 							return err
 						}
-						if err := updateMany(ctx, tx, "key", 100, 500); err != nil {
+						if _, err := updateMany(ctx, tx, "key", 100, 500); err != nil {
 							return err
 						}
-						if err := deleteMany(ctx, tx, "key", 500); err != nil {
+						if _, err := deleteMany(ctx, tx, "key", 500); err != nil {
 							return err
 						}
 						return nil
@@ -109,10 +109,10 @@ func BenchmarkCompaction(b *testing.B) {
 					// that the deleted rows are about 5% of the total.
 					addCount := delCount * 20
 
-					if err := insertMany(ctx, tx, "key", 100, addCount); err != nil {
+					if _, err := insertMany(ctx, tx, "key", 100, addCount); err != nil {
 						return err
 					}
-					if err := deleteMany(ctx, tx, "key", delCount); err != nil {
+					if _, err := deleteMany(ctx, tx, "key", delCount); err != nil {
 						return err
 					}
 					return nil

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -101,7 +101,7 @@ func TestGet(t *testing.T) {
 				key := "testKeyFailNotFound"
 
 				// Delete key
-				deleteKey(ctx, g, kine.client, key)
+				deleteKey(ctx, g, kine.client, key, 0)
 
 				// Get key
 				resp, err := kine.client.Get(ctx, key, clientv3.WithRange(""))
@@ -125,10 +125,10 @@ func BenchmarkGet(b *testing.B) {
 			kine := newKineServer(ctx, b, &kineOptions{
 				backendType: backendType,
 				setup: func(ctx context.Context, tx *sql.Tx) error {
-					if err := insertMany(ctx, tx, "testKey", 100, b.N*2); err != nil {
+					if _, err := insertMany(ctx, tx, "testKey", 100, b.N*2); err != nil {
 						return err
 					}
-					if err := updateMany(ctx, tx, "testKey", 100, b.N); err != nil {
+					if _, err := updateMany(ctx, tx, "testKey", 100, b.N); err != nil {
 						return err
 					}
 					return nil

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -180,13 +180,13 @@ func TestList(t *testing.T) {
 
 func BenchmarkList(b *testing.B) {
 	setup := func(ctx context.Context, tx *sql.Tx, payloadSize, n int) error {
-		if err := insertMany(ctx, tx, "key", payloadSize, n); err != nil {
+		if _, err := insertMany(ctx, tx, "key", payloadSize, n); err != nil {
 			return err
 		}
-		if err := updateMany(ctx, tx, "key", payloadSize, n/2); err != nil {
+		if _, err := updateMany(ctx, tx, "key", payloadSize, n/2); err != nil {
 			return err
 		}
-		if err := deleteMany(ctx, tx, "key", n/2); err != nil {
+		if _, err := deleteMany(ctx, tx, "key", n/2); err != nil {
 			return err
 		}
 		return nil

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -86,8 +86,8 @@ func TestUpdate(t *testing.T) {
 			t.Run("UpdatedDeletedKeyFails", func(t *testing.T) {
 				g := NewWithT(t)
 
-				createKey(ctx, g, kine.client, "updateDeletedKey", "testValue4")
-				lastModRev := deleteKey(ctx, g, kine.client, "updateDeletedKey")
+				lastModRev := createKey(ctx, g, kine.client, "updateDeletedKey", "testValue4")
+				lastModRev = deleteKey(ctx, g, kine.client, "updateDeletedKey", lastModRev)
 
 				resp, err := kine.client.Txn(ctx).
 					If(clientv3.Compare(clientv3.ModRevision("updateDeletedKey"), "=", lastModRev)).


### PR DESCRIPTION
The delete benchmark right now is using the path for the "[unconditional delete](https://github.com/kubernetes/kubernetes/blob/v1.14.0/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L191)" which is what k8s 1.14 and previous was using. 

Since v1.15 it is now using a [conditional delete](https://github.com/kubernetes/kubernetes/blob/v1.32.0-alpha.0/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L277) instead.

As such, that is what we should test.