### PR TITLE
Fix watch test

### DIFF
--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -319,7 +319,10 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				? AS name,
 				0 AS created,
 				0 AS deleted,
-				create_revision,
+				CASE 
+					WHEN kine.created THEN id
+					ELSE create_revision
+				END AS create_revision,
 				id AS prev_revision,
 				? AS lease,
 				? AS value,

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -590,6 +590,10 @@ func scan(rows *sql.Rows, event *server.Event) error {
 	if event.Create {
 		event.KV.CreateRevision = event.KV.ModRevision
 		event.PrevKV = nil
+	} else {
+		event.PrevKV.Key = event.KV.Key
+		event.PrevKV.CreateRevision = event.KV.CreateRevision
+		event.PrevKV.Lease = event.KV.Lease
 	}
 
 	return nil

--- a/pkg/kine/server/watch.go
+++ b/pkg/kine/server/watch.go
@@ -111,6 +111,7 @@ func toEvent(event *Event) *mvccpb.Event {
 	}
 	if event.Delete {
 		e.Type = mvccpb.DELETE
+		e.Kv.Value = nil
 	} else {
 		e.Type = mvccpb.PUT
 	}


### PR DESCRIPTION
The current watch test has inter dependencies from subtests and as such subtests cannot be run individually, but only as a whole.

This PR attempts to overcome this issue and make them independent. 

It also fixes some checks:
 - `KV.Value` in delete event should be `nil`
 - `PrevKV.Key` should be correctly populated
 - `[Prev]KV.CreateRevision` should be correctly populated

These new checks highlighted a small bug in the update query which should now be fixed.