### PR TITLE
Increase parallelism for write benchmarks

### DIFF
--- a/test/create_test.go
+++ b/test/create_test.go
@@ -38,7 +38,7 @@ func TestCreate(t *testing.T) {
 // BenchmarkCreate is a benchmark for the Create operation.
 func BenchmarkCreate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
-		for _, workers := range []int{1, 2, 4, 8, 16} {
+		for _, workers := range []int{1, 4, 16, 64, 128} {
 			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -67,7 +67,7 @@ func TestDelete(t *testing.T) {
 // BenchmarkDelete is a benchmark for the delete operation.
 func BenchmarkDelete(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
-		for _, workers := range []int{1, 2, 4, 8, 16} {
+		for _, workers := range []int{1, 4, 16, 64, 128} {
 			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -107,7 +107,7 @@ func TestUpdate(t *testing.T) {
 // BenchmarkUpdate is a benchmark for the Update operation.
 func BenchmarkUpdate(b *testing.B) {
 	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
-		for _, workers := range []int{1, 2, 4, 8, 16} {
+		for _, workers := range []int{1, 4, 16, 64, 128} {
 			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()
 				g := NewWithT(b)


### PR DESCRIPTION
This PR increases the number of concurrent writers in the write loads.

This is useful to showcase how processing will change once #180 is ready.