### PR TITLE
K8s-snap integration test with k8s-dqlite changes

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -2,8 +2,7 @@ name: Integration Test K8s-snap
 
 on:
   push:
-    # TODO:rm my branch
-    branches: ["master", "KU-1213/k8s-snap-build"]
+    branches: ["master"]
   pull_request:
 
 permissions:
@@ -49,8 +48,6 @@ jobs:
       - name: Repack Snap
         run: |
           sudo mksquashfs snap-unpack-dir k8s-updated.snap -noappend -comp lzo -no-fragments
-          ls ${{ github.workspace }}/k8s-updated.snap
-          pwd # TODO:rm
       - name: Running
         env:
           TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -29,7 +29,7 @@ jobs:
           go-version: "1.21"
       - name: Download latest k8s-snap
         run: |
-          sudo snap install k8s --channel=latest/edge --classic
+          sudo snap download k8s --channel=latest/edge --basename k8s
       - name: Install lxd
         run: |
           sudo snap refresh lxd --channel 5.21/stable
@@ -39,14 +39,24 @@ jobs:
       - name: Build k8s-dqlite
         run: |
           make static  
-      - name: Swap out k8s-dqlite
+      # Unpack the snap and swap out the k8s-dqlite binary
+      - name: Unpack Snap
         run: |
-          sudo cp ./bin/static/k8s-dqlite /var/snap/k8s/common/var/lib/k8s-dqlite
-          # sudo chown root:root /var/snap/k8s/common/var/lib/k8s-dqlite
-          # sudo chmod 755 /var/snap/k8s/common/var/lib/k8s-dqlite   
+          sudo unsquashfs -d snap-unpack-dir k8s.snap
+
+      - name: Replace k8s-dqlite binary
+        run: |
+          # Ensure the target directory exists and copy the new binary
+          sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
+          sudo chmod +x snap-unpack-dir/bin/k8s-dqlite  # Ensure the binary is executable
+      - name: Repack Snap
+        run: |
+          sudo mksquashfs snap-unpack-dir k8s-updated.snap -noappend -comp xz
+          ls -a # TODO:rm
+
       - name: Running
         env:
-          TEST_SNAP: /var/snap/k8s/current
+          TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ubuntu:24.04
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     name: Build K8-dqlite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checking out repo
@@ -39,31 +39,28 @@ jobs:
       - name: Build k8s-dqlite
         run: |
           make static  
-      # Unpack the snap and swap out the k8s-dqlite binary
       - name: Unpack Snap
         run: |
           sudo unsquashfs -d snap-unpack-dir k8s.snap
-
       - name: Replace k8s-dqlite binary
         run: |
-          # Ensure the target directory exists and copy the new binary
           sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
-          sudo chmod +x snap-unpack-dir/bin/k8s-dqlite  # Ensure the binary is executable
+          sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
       - name: Repack Snap
         run: |
-          sudo mksquashfs snap-unpack-dir k8s-updated.snap -noappend -comp xz
-          ls -a # TODO:rm
-
+          sudo mksquashfs snap-unpack-dir k8s-updated.snap -noappend -comp lzo -no-fragments
+          ls ${{ github.workspace }}/k8s-updated.snap
+          pwd # TODO:rm
       - name: Running
         env:
           TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap
           TEST_SUBSTRATE: lxd
-          TEST_LXD_IMAGE: ubuntu:24.04
+          TEST_LXD_IMAGE: ubuntu:22.04
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+          TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
         run: |
           git clone https://github.com/canonical/k8s-snap.git      
           cd k8s-snap/tests/integration && sg lxd -c 'tox -e integration'
-
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -54,7 +54,6 @@ jobs:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ubuntu:22.04
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
-          TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
         run: |
           git clone https://github.com/canonical/k8s-snap.git      
           cd k8s-snap/tests/integration && sg lxd -c 'tox -e integration'

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -2,6 +2,7 @@ name: Integration Test K8s-snap
 
 on:
   push:
+    # TODO:rm my branch
     branches: ["master", "KU-1213/k8s-snap-build"]
   pull_request:
 
@@ -40,9 +41,9 @@ jobs:
           make static  
       - name: Swap out k8s-dqlite
         run: |
-          sudo cp ./bin/static/k8s-dqlite /var/snap/k8s/current/bin/k8s-dqlite
-          sudo chown root:root /var/snap/k8s/current/bin/k8s-dqlite
-          sudo chmod 755 /var/snap/k8s/current/bin/k8s-dqlite   
+          sudo cp ./bin/static/k8s-dqlite /var/snap/k8s/common/var/lib/k8s-dqlite
+          # sudo chown root:root /var/snap/k8s/common/var/lib/k8s-dqlite
+          # sudo chmod 755 /var/snap/k8s/common/var/lib/k8s-dqlite   
       - name: Running
         env:
           TEST_SNAP: /var/snap/k8s/current

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -51,8 +51,7 @@ jobs:
           TEST_LXD_IMAGE: ubuntu:24.04
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
-          mkdir dir
-          git clone https://github.com/k8s-snap.git      
+          git clone https://github.com/canonical/k8s-snap.git      
           cd k8s-snap/tests/integration && sg lxd -c 'tox -e integration'
 
       - name: Prepare inspection reports

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -1,0 +1,67 @@
+name: Integration Test K8s-snap
+
+on:
+  push:
+    branches: ["master", "KU-1213/k8s-snap-build"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build K8-dqlite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Install tox
+        run: pip install tox
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: Download latest k8s-snap
+        run: |
+          sudo snap install k8s --channel=latest/edge --classic
+      - name: Install lxd
+        run: |
+          sudo snap refresh lxd --channel 5.21/stable
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd $USER
+          sg lxd -c 'lxc version'
+      - name: Build k8s-dqlite
+        run: |
+          make static  
+      - name: Swap out k8s-dqlite
+        run: |
+          sudo cp ./bin/static/k8s-dqlite /var/snap/k8s/current/bin/k8s-dqlite
+          sudo chown root:root /var/snap/k8s/current/bin/k8s-dqlite
+          sudo chmod 755 /var/snap/k8s/current/bin/k8s-dqlite   
+      - name: Running
+        env:
+          TEST_SNAP: /var/snap/k8s/current
+          TEST_SUBSTRATE: lxd
+          TEST_LXD_IMAGE: ubuntu:24.04
+          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+        run: |
+          mkdir dir
+          git clone https://github.com/k8s-snap.git      
+          cd k8s-snap/tests/integration && sg lxd -c 'tox -e integration'
+
+      - name: Prepare inspection reports
+        if: failure()
+        run: |
+          tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+      - name: Upload inspection report artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inspection-reports
+          path: ${{ github.workspace }}/inspection-reports.tar.gz
+    


### PR DESCRIPTION
# K8s-snap integration test with k8s-dqlite changes
This PR adds a test for our newest changes of k8s-dqlite against our latest [k8s-snap](https://github.com/canonical/k8s-snap).
Through this test we can guarantee k8s features (network, ingress, gateway, storage, etc) work as expected. 
