### PR TITLE
Cancel concurrent workflow k8s-snap integration test

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build K8-dqlite
@@ -19,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Install tox
         run: pip install tox
       - name: Install Go
@@ -37,7 +41,7 @@ jobs:
           sg lxd -c 'lxc version'
       - name: Build k8s-dqlite
         run: |
-          make static  
+          make static
       - name: Unpack Snap
         run: |
           sudo unsquashfs -d snap-unpack-dir k8s.snap
@@ -67,4 +71,3 @@ jobs:
         with:
           name: inspection-reports
           path: ${{ github.workspace }}/inspection-reports.tar.gz
-    

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,17 +55,15 @@ and connect to the Dqlite database.
 
 Follow the guide for MicroK8s steps 1-5 while changing the snap name to `k8s`.
 
-Step 5:
-Stop k8s-dqlite included in the snap:
+5. Stop k8s-dqlite included in the snap:
 
-    ```bash
+    ```
     sudo snap stop k8s.k8s-dqlite --disable
     ```
 
-Step 6:
-This step is different as it uses a different path for the storage directory and the listen address:
+6. This step is different as it uses a different path for the storage directory and the listen address:
 
-    ```bash
+    ```
     cd k8s-dqlite
     make static
     sudo ./bin/static/k8s-dqlite \


### PR DESCRIPTION
# Cancel concurrent workflow k8s-snap integration test.
Through this PR we cancel in flight integration tests that are running when newer changes are pushed.
