### PR TITLE
Fix sqlite initialization flags

### DIFF
--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -53,11 +53,11 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connecti
 	}
 	logrus.Printf("DriverName is %s.", driverName)
 
-	if dataSourceName == "" {
+	if opts.dsn == "" {
 		if err := os.MkdirAll("./db", 0700); err != nil {
 			return nil, nil, err
 		}
-		dataSourceName = "./db/state.db?_journal=WAL&cache=shared"
+		opts.dsn = "./db/state.db?_journal=WAL&_synchronous=FULL&_foreign_keys=1"
 	}
 
 	dialect, err := generic.Open(ctx, driverName, opts.dsn, connectionPoolConfig, "?", false)
@@ -212,7 +212,7 @@ func parseOpts(dsn string) (opts, error) {
 			}
 			result.watchQueryTimeout = d
 		default:
-			return opts{}, fmt.Errorf("unknown option %s=%v", k, vs)
+			continue
 		}
 		delete(values, k)
 	}

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -128,7 +128,7 @@ func newKineServer(ctx context.Context, tb testing.TB, options *kineOptions) *ki
 }
 
 func startSqlite(_ context.Context, tb testing.TB, dir string) (*endpoint.Config, *sql.DB) {
-	dbPath := path.Join(dir, "data.db")
+	dbPath := path.Join(dir, "data.db") + "?_journal=WAL&_synchronous=FULL&_foreign_keys=1"
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {


### PR DESCRIPTION
This PR changes the way sqlite is initialized, so that it is similar (in terms of guarantees) to what dqlite is doing.

As such, we want:
 - WAL mode (it was journal mode before);
 - synchronous=FULL (dqlite protects commits from power outages once committed)
 - checked foreign_keys

This might be one of the reasons we see sometimes very different results from dqlite and sqlite.