### PR TITLE
Simplify keys read path

### DIFF
--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -60,7 +60,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connecti
 		opts.dsn = "./db/state.db?_journal=WAL&_synchronous=FULL&_foreign_keys=1"
 	}
 
-	dialect, err := generic.Open(ctx, driverName, opts.dsn, connectionPoolConfig, "?", false)
+	dialect, err := generic.Open(ctx, driverName, opts.dsn, connectionPoolConfig)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -84,7 +84,6 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connecti
 		}
 		return err
 	}
-	dialect.GetSizeSQL = `SELECT (page_count - freelist_count) * page_size FROM pragma_page_count(), pragma_page_size(), pragma_freelist_count()`
 
 	dialect.CompactInterval = opts.compactInterval
 	dialect.PollInterval = opts.pollInterval

--- a/pkg/kine/logstructured/logstructured.go
+++ b/pkg/kine/logstructured/logstructured.go
@@ -70,6 +70,7 @@ func (l *LogStructured) Start(ctx context.Context) error {
 
 func (l *LogStructured) Wait() {
 	l.wg.Wait()
+	l.log.Wait()
 }
 
 func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (revRet int64, kvRet *server.KeyValue, errRet error) {

--- a/pkg/kine/logstructured/logstructured.go
+++ b/pkg/kine/logstructured/logstructured.go
@@ -190,21 +190,7 @@ func (l *LogStructured) Count(ctx context.Context, prefix, startKey string, revi
 		span.RecordError(err)
 		span.End()
 	}()
-	rev, count, err := l.log.Count(ctx, prefix, startKey, revision)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if count == 0 {
-		// if count is zero, then so is revision, so now get the current revision and re-count at that revision
-		currentRev, err := l.log.CurrentRevision(ctx)
-		if err != nil {
-			return 0, 0, err
-		}
-		rev, rows, err := l.List(ctx, prefix, prefix, 1000, currentRev)
-		return rev, int64(len(rows)), err
-	}
-	return rev, count, nil
+	return l.log.Count(ctx, prefix, startKey, revision)
 }
 
 func (l *LogStructured) Update(ctx context.Context, key string, value []byte, revision, lease int64) (revRet int64, updateRet bool, errRet error) {

--- a/pkg/kine/logstructured/sqllog/sql.go
+++ b/pkg/kine/logstructured/sqllog/sql.go
@@ -260,12 +260,6 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 		return 0, nil, err
 	}
 
-	if revision > 0 && revision < compactRevision {
-		return currentRevision, result, server.ErrCompacted
-	}
-
-	s.notifyWatcherPoll(currentRevision)
-
 	return currentRevision, result, err
 }
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -120,7 +120,7 @@ func BenchmarkUpdate(b *testing.B) {
 				run := func(start int) {
 					defer wg.Done()
 					benchKey := fmt.Sprintf("benchKey-%d", start)
-					for i, lastModRev := 0, int64(0); i < b.N; i += workers {
+					for i, lastModRev := start, int64(0); i < b.N; i += workers {
 						value := fmt.Sprintf("value-%d", i)
 						lastModRev = updateRev(ctx, g, kine.client, benchKey, lastModRev, value)
 					}


### PR DESCRIPTION
This PR aims to simplify the read path by:

 - merging the query for `{List, Count}Current` with `{List, Count}`. The count query might have a slight increase in latency, but not important enough to care
 - solving a potential (and rare) concurrency bug for the `List` query: the revision was fetched after the list, so we might have returned the wrong version for the list
 - removing the logic to support mysql and postgres parameter naming
 - removing the customization hooks for other dialects