### PR TITLE
Add Trivy scan for release branches

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,7 +1,6 @@
 name: Trivy
 
 on:
-  pull_request:
   schedule:
     - cron: '0 10 * * *'
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 10 * * *'
 
 jobs:
-  prepare:
+  list-branches-to-scan:
     runs-on: ubuntu-latest
     outputs:
       branches: ${{ steps.branches.outputs.branches }}
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Create branches to test
+      - name: List branches to scan
         id: branches
         run: |
           # regex matches branches like
@@ -29,10 +29,10 @@ jobs:
           echo "branches=$(echo $BRANCHES)" >> $GITHUB_OUTPUT
   scan:
     runs-on: ubuntu-latest
-    needs: prepare
+    needs: list-branches-to-scan
     strategy:
       matrix:
-        branch: ${{ fromJson(needs.prepare.outputs.branches) }}
+        branch: ${{ fromJson(needs.list-branches-to-scan.outputs.branches) }}
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Create branches to test
         id: branches
         run: |
+          # regex matches branches like
+          #  origin/1.28
+          #  origin/v1.1
+          #  origin/release-1.30
+          #  origin/master
+          #  origin/main
           BRANCHES=$(git branch -r | grep  -E '^  origin\/(((v|release-)?[0-9]+.[0-9]+)|(master|main))$' | \
             sed -e 's#^  origin/##'  | jq -R -s -c 'split("\n")[:-1]')
           echo "branches=$(echo $BRANCHES)" >> $GITHUB_OUTPUT

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,11 +6,27 @@ on:
     - cron: '0 10 * * *'
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.branches.outputs.branches }}
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create branches to test
+        id: branches
+        run: |
+          BRANCHES=$(git branch -r | grep  -E '^  origin\/(((v|release-)?[0-9]+.[0-9]+)|(master|main))$' | \
+            sed -e 's#^  origin/##'  | jq -R -s -c 'split("\n")[:-1]')
+          echo "branches=$(echo $BRANCHES)" >> $GITHUB_OUTPUT
   scan:
     runs-on: ubuntu-latest
+    needs: prepare
     strategy:
       matrix:
-        branch: [master]
+        branch: ${{ fromJson(needs.prepare.outputs.branches) }}
     permissions:
       security-events: write
     steps:
@@ -18,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
+          fetch-depth: 0
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.28.0
         with:
@@ -26,6 +43,8 @@ jobs:
           format: "sarif"
           output: "output.sarif"
           severity: "MEDIUM,HIGH,CRITICAL"
+        env:
+          TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db"
       - name: Get commit sha
         run: |
           SHA="$(git rev-parse HEAD)"


### PR DESCRIPTION
This pr adds trivy scan for release branches
KU-2031

*Also verify you have:*

* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
