### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security issue, please follow the steps below:
+
+Using GitHub, file a [Private Security Report](https://github.com/canonical/k8s-dqlite/security/advisories/new) with:
+- A description of the issue
+- Steps to reproduce the issue
+- Affected versions of the `k8s-dqlite` package
+- Any known mitigations for the issue
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what to expect during this process and our requirements for responsible disclosure.
+
+Thank you for contributing to the security and integrity of the `k8s-dqlite`!


### PR DESCRIPTION
This pr adds security.md and introduces a policy enabling users to report security issues.

KU-2046


*Also verify you have:*

* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
