### PR TITLE
v1.3.0 tag versioning docs

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,7 +15,8 @@ Here is an overview that shows which k8s-dqlite version aligns with which suppor
 | K8s-dqlite Tag     | K8s-dqlite Branch  | Kubernetes Version |
 |--------------------|--------------------|--------------------|
 | 1.1.11             | v1.1               | 1.28-1.30          |
-| 1.2.0              | master             | 1.31               |
+| 1.2.0              | v1.2               | 1.31               |
+| 1.3.0              | master             | 1.32               |
 
 Note: K8s-dqlite tags `v1.1.7` and branch `1.28` are prior to the major refactor from [Canonical kine](https://github.com/canonical/kine).
 All supported products prior to k8s `1.31` use the `v1.1.11` tag for which the `v1.1` branch tracks its patches.


### PR DESCRIPTION
## v1.3.0 tag versioning docs
This PR updates the versioning docs to include the new v1.3.0 tag.