### PR TITLE
Emulated etcd version

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -14,11 +14,7 @@ concurrency:
 
 jobs:
   build:
-    name: K8s-snap Integration Test ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+    name: K8s-snap Integration Test
     runs-on: ubuntu-20.04
 
     steps:
@@ -60,7 +56,7 @@ jobs:
         env:
           TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap
           TEST_SUBSTRATE: lxd
-          TEST_LXD_IMAGE: ${{ matrix.os }}
+          TEST_LXD_IMAGE: ubuntu:22.04
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
           git clone https://github.com/canonical/k8s-snap.git      

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -2,7 +2,7 @@ name: Integration Test K8s-snap
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "KU-2276/emulated-etcd-version"] #TODO remove KU-2276/emulated-etcd-version
   pull_request:
 
 permissions:
@@ -14,7 +14,11 @@ concurrency:
 
 jobs:
   build:
-    name: K8s-snap Integration Test
+    name: K8s-snap Integration Test ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
     runs-on: ubuntu-20.04
 
     steps:
@@ -30,9 +34,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
-      - name: Download latest k8s-snap
+      - name: Download latest k8s-snap #TODO remove v1.32.0-rc0
         run: |
-          sudo snap download k8s --channel=latest/edge --basename k8s
+          sudo snap download k8s --channel=latest/edge/v1.32.0-rc0 --basename k8s
       - name: Install lxd
         run: |
           sudo snap refresh lxd --channel 5.21/stable
@@ -56,7 +60,7 @@ jobs:
         env:
           TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap
           TEST_SUBSTRATE: lxd
-          TEST_LXD_IMAGE: ubuntu:22.04
+          TEST_LXD_IMAGE: ${{ matrix.os }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
           git clone https://github.com/canonical/k8s-snap.git      

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -2,7 +2,7 @@ name: Integration Test K8s-snap
 
 on:
   push:
-    branches: ["master", "KU-2276/emulated-etcd-version"] #TODO remove KU-2276/emulated-etcd-version
+    branches: ["master"]
   pull_request:
 
 permissions:
@@ -34,9 +34,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
-      - name: Download latest k8s-snap #TODO remove v1.32.0-rc0
+      - name: Download latest k8s-snap
         run: |
-          sudo snap download k8s --channel=latest/edge/v1.32.0-rc0 --basename k8s
+          sudo snap download k8s --channel=latest/edge --basename k8s
       - name: Install lxd
         run: |
           sudo snap refresh lxd --channel 5.21/stable

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var (
 		metricsAddress         string
 		otel                   bool
 		otelAddress            string
+		emulatedEtcdVersion    string
 
 		connectionPoolConfig generic.ConnectionPoolConfig
 
@@ -101,6 +102,7 @@ var (
 				rootCmdOpts.diskMode,
 				rootCmdOpts.clientSessionCacheSize,
 				rootCmdOpts.minTLSVersion,
+				rootCmdOpts.emulatedEtcdVersion,
 				rootCmdOpts.watchAvailableStorageInterval,
 				rootCmdOpts.watchAvailableStorageMinBytes,
 				rootCmdOpts.lowAvailableStorageAction,
@@ -173,6 +175,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootCmdOpts.otel, "otel", false, "enable traces endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.otelAddress, "otel-listen", "127.0.0.1:4317", "listen address for OpenTelemetry endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
+	rootCmd.Flags().StringVar(&rootCmdOpts.emulatedEtcdVersion, "emulated-etcd-version", "3.5.13", "The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.13, in order to indicate support for watch progress notifications.")
 	rootCmd.Flags().IntVar(&rootCmdOpts.connectionPoolConfig.MaxIdle, "datastore-max-idle-connections", 5, "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.")
 	rootCmd.Flags().IntVar(&rootCmdOpts.connectionPoolConfig.MaxOpen, "datastore-max-open-connections", 5, "Maximum number of open connections used by datastore. If value <= 0, then there is no limit")
 	rootCmd.Flags().DurationVar(&rootCmdOpts.connectionPoolConfig.MaxLifetime, "datastore-connection-max-lifetime", 60*time.Second, "Maximum amount of time a connection may be reused. If value <= 0, then there is no limit.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -175,7 +175,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootCmdOpts.otel, "otel", false, "enable traces endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.otelAddress, "otel-listen", "127.0.0.1:4317", "listen address for OpenTelemetry endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.metricsAddress, "metrics-listen", "127.0.0.1:9042", "listen address for metrics endpoint")
-	rootCmd.Flags().StringVar(&rootCmdOpts.emulatedEtcdVersion, "emulated-etcd-version", "3.5.13", "The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.13, in order to indicate support for watch progress notifications.")
+	rootCmd.Flags().StringVar(&rootCmdOpts.emulatedEtcdVersion, "emulated-etcd-version", "3.5.12", "The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.12, in order to indicate no support for watch progress notifications yet.")
 	rootCmd.Flags().IntVar(&rootCmdOpts.connectionPoolConfig.MaxIdle, "datastore-max-idle-connections", 5, "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.")
 	rootCmd.Flags().IntVar(&rootCmdOpts.connectionPoolConfig.MaxOpen, "datastore-max-open-connections", 5, "Maximum number of open connections used by datastore. If value <= 0, then there is no limit")
 	rootCmd.Flags().DurationVar(&rootCmdOpts.connectionPoolConfig.MaxLifetime, "datastore-connection-max-lifetime", 60*time.Second, "Maximum amount of time a connection may be reused. If value <= 0, then there is no limit.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ The following configuration options are available listed in a table format:
 | `--otel` | Enable traces endpoint | `false` |
 | `--otel-listen` | The address to listen for OpenTelemetry endpoint | `127.0.0.1:4317` |
 | `--metrics-listen` | The address to listen for metrics endpoint | `127.0.0.1:9042` |
-| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.13, in order to indicate support for watch progress notifications. | `3.5.13` |
+| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.12, in order to indicate no support for watch progress notifications yet. | `3.5.12` |
 | `--datastore-max-idle-connections` | Maximum number of idle connections retained by datastore | `5` |
 | `--datastore-max-open-connections` | Maximum number of open connections used by datastore | `5` |
 | `--datastore-connection-max-lifetime` | Maximum amount of time a connection may be reused | `60s` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ The following configuration options are available listed in a table format:
 | `--otel` | Enable traces endpoint | `false` |
 | `--otel-listen` | The address to listen for OpenTelemetry endpoint | `127.0.0.1:4317` |
 | `--metrics-listen` | The address to listen for metrics endpoint | `127.0.0.1:9042` |
+| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.13, in order to indicate support for watch progress notifications. | `3.5.13` |
 | `--datastore-max-idle-connections` | Maximum number of idle connections retained by datastore | `5` |
 | `--datastore-max-open-connections` | Maximum number of open connections used by datastore | `5` |
 | `--datastore-connection-max-lifetime` | Maximum amount of time a connection may be reused | `60s` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ The following configuration options are available listed in a table format:
 | `--otel` | Enable traces endpoint | `false` |
 | `--otel-listen` | The address to listen for OpenTelemetry endpoint | `127.0.0.1:4317` |
 | `--metrics-listen` | The address to listen for metrics endpoint | `127.0.0.1:9042` |
-| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.12, in order to indicate no support for watch progress notifications yet. | `3.5.12` |
+| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.7, in order to indicate no support for watch progress notifications yet. | `3.5.7` |
 | `--datastore-max-idle-connections` | Maximum number of idle connections retained by datastore | `5` |
 | `--datastore-max-open-connections` | Maximum number of open connections used by datastore | `5` |
 | `--datastore-connection-max-lifetime` | Maximum amount of time a connection may be reused | `60s` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ The following configuration options are available listed in a table format:
 | `--otel` | Enable traces endpoint | `false` |
 | `--otel-listen` | The address to listen for OpenTelemetry endpoint | `127.0.0.1:4317` |
 | `--metrics-listen` | The address to listen for metrics endpoint | `127.0.0.1:9042` |
-| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.7, in order to indicate no support for watch progress notifications yet. | `3.5.7` |
+| `--emulated-etcd-version` | The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.12, in order to indicate no support for watch progress notifications yet. | `3.5.12` |
 | `--datastore-max-idle-connections` | Maximum number of idle connections retained by datastore | `5` |
 | `--datastore-max-open-connections` | Maximum number of open connections used by datastore | `5` |
 | `--datastore-connection-max-lifetime` | Maximum amount of time a connection may be reused | `60s` |

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -30,8 +30,8 @@ type Config struct {
 	GRPCServer           *grpc.Server
 	Listener             string
 	Endpoint             string
+	EmulatedEtcdVersion  string
 	ConnectionPoolConfig generic.ConnectionPoolConfig
-
 	tls.Config
 }
 
@@ -65,7 +65,7 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 		listen = KineSocket
 	}
 
-	b := server.New(backend)
+	b := server.New(backend, config.EmulatedEtcdVersion)
 	grpcServer := grpcServer(config)
 	b.Register(grpcServer)
 
@@ -130,7 +130,7 @@ func ListenAndReturnBackend(ctx context.Context, config Config) (ETCDConfig, ser
 		listen = KineSocket
 	}
 
-	b := server.New(backend)
+	b := server.New(backend, config.EmulatedEtcdVersion)
 	grpcServer := grpcServer(config)
 	b.Register(grpcServer)
 

--- a/pkg/kine/server/get.go
+++ b/pkg/kine/server/get.go
@@ -23,11 +23,9 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		attribute.Int64("revision", r.Revision),
 	)
 
-	if len(r.RangeEnd) != 0 {
-		return nil, fmt.Errorf("unexpected rangeEnd: want empty, got %s", r.RangeEnd)
-	}
-	if r.Limit != 0 {
-		return nil, fmt.Errorf("unexpected limit: want 0, got %d", r.Limit)
+	if r.Limit != 0 && len(r.RangeEnd) != 0 {
+		err := fmt.Errorf("invalid combination of rangeEnd and limit, limit should be 0 got %d", r.Limit)
+		return nil, err
 	}
 
 	rev, kv, err := l.backend.List(ctx, string(r.Key), "", 1, r.Revision)

--- a/pkg/kine/server/maintenance.go
+++ b/pkg/kine/server/maintenance.go
@@ -19,8 +19,9 @@ func (s *KVServerBridge) Status(ctx context.Context, r *etcdserverpb.StatusReque
 		return nil, err
 	}
 	return &etcdserverpb.StatusResponse{
-		Header: &etcdserverpb.ResponseHeader{},
-		DbSize: size,
+		Header:  &etcdserverpb.ResponseHeader{},
+		DbSize:  size,
+		Version: s.emulatedETCDVersion,
 	}, nil
 }
 

--- a/pkg/kine/server/maintenance.go
+++ b/pkg/kine/server/maintenance.go
@@ -21,7 +21,7 @@ func (s *KVServerBridge) Status(ctx context.Context, r *etcdserverpb.StatusReque
 	return &etcdserverpb.StatusResponse{
 		Header:  &etcdserverpb.ResponseHeader{},
 		DbSize:  size,
-		Version: s.emulatedETCDVersion,
+		Version: s.emulatedEtcdVersion,
 	}, nil
 }
 

--- a/pkg/kine/server/server.go
+++ b/pkg/kine/server/server.go
@@ -18,11 +18,13 @@ var (
 )
 
 type KVServerBridge struct {
-	limited *LimitedServer
+	limited             *LimitedServer
+	emulatedETCDVersion string
 }
 
-func New(backend Backend) *KVServerBridge {
+func New(backend Backend, emulatedEtcdVersion string) *KVServerBridge {
 	return &KVServerBridge{
+		emulatedETCDVersion: emulatedEtcdVersion,
 		limited: &LimitedServer{
 			backend: backend,
 		},

--- a/pkg/kine/server/server.go
+++ b/pkg/kine/server/server.go
@@ -19,12 +19,12 @@ var (
 
 type KVServerBridge struct {
 	limited             *LimitedServer
-	emulatedETCDVersion string
+	emulatedEtcdVersion string
 }
 
 func New(backend Backend, emulatedEtcdVersion string) *KVServerBridge {
 	return &KVServerBridge{
-		emulatedETCDVersion: emulatedEtcdVersion,
+		emulatedEtcdVersion: emulatedEtcdVersion,
 		limited: &LimitedServer{
 			backend: backend,
 		},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,7 @@ func New(
 	diskMode bool,
 	clientSessionCacheSize uint,
 	minTLSVersion string,
+	emulatedEtcdVersion string,
 	watchAvailableStorageInterval time.Duration,
 	watchAvailableStorageMinBytes uint64,
 	lowAvailableStorageAction string,
@@ -222,6 +223,8 @@ func New(
 	}
 	// set datastore connection pool options
 	kineConfig.ConnectionPoolConfig = connectionPoolConfig
+	// set emulated etcd version
+	kineConfig.EmulatedEtcdVersion = emulatedEtcdVersion
 	// handle tuning parameters
 	if exists, err := fileExists(dir, "tuning.yaml"); err != nil {
 		return nil, fmt.Errorf("failed to check for tuning.yaml: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -343,7 +343,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start kine: %w", err)
 	}
-	logrus.WithFields(logrus.Fields{"address": s.kineConfig.Listener, "database": s.kineConfig.Endpoint}).Print("Started kine")
+	logrus.WithFields(logrus.Fields{"address": s.kineConfig.Listener, "database": s.kineConfig.Endpoint, "emulatedEtcdVersion": s.kineConfig.EmulatedEtcdVersion}).Print("Started kine")
 
 	s.backend = backend
 


### PR DESCRIPTION
## Emulated etcd version

Support for etcd version check that evaluates whether RequestWatchProgress is supported by the current version of etcd endpoint from status request: https://github.com/kubernetes/kubernetes/blob/beb696c2c9467dbc44cbaf35c5a4a3daf0321db3/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go#L157

Affected upstream k8s features: `ConsistentListFromCache`, `WatchList`.

Backport of https://github.com/k3s-io/kine/pull/316.

This PR defines an emulated etcd version that signifies the RequestWatchProgress is not yet supported. Only once k8s-dqlite supports WatchProgressRequests we can bump the version to signal the feature's support.

Tested with 1.32 rc: https://github.com/canonical/k8s-dqlite/actions/runs/12237343236