### PR TITLE
refactor: return driver from drivers methods

### DIFF
--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -25,11 +25,11 @@ func init() {
 	}
 }
 
-func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Dialect, error) {
+func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
 	return NewVariant(ctx, datasourceName, connectionPoolConfig)
 }
 
-func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Dialect, error) {
+func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
 	logrus.Printf("New kine for dqlite")
 
 	// Driver name will be extracted from query parameters

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -11,7 +11,6 @@ import (
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/sqllog"
-	"github.com/canonical/k8s-dqlite/pkg/kine/tls"
 	"github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -24,15 +23,10 @@ func init() {
 	}
 }
 
-func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
-	return NewVariant(ctx, datasourceName, connectionPoolConfig)
-}
-
-func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
+func New(ctx context.Context, driverName, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
 	logrus.Printf("New kine for dqlite")
 
-	// Driver name will be extracted from query parameters
-	driver_, err := sqlite.NewVariant(ctx, "", datasourceName, connectionPoolConfig)
+	driver_, err := sqlite.New(ctx, driverName, datasourceName, connectionPoolConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -23,10 +23,10 @@ func init() {
 	}
 }
 
-func New(ctx context.Context, driverName, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
+func NewDriver(ctx context.Context, driverName, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
 	logrus.Printf("New kine for dqlite")
 
-	driver_, err := sqlite.New(ctx, driverName, datasourceName, connectionPoolConfig)
+	driver_, err := sqlite.NewDriver(ctx, driverName, datasourceName, connectionPoolConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -244,13 +244,6 @@ type Generic struct {
 	DB         database.Interface
 	Retry      ErrRetry
 	ErrCode    ErrCode
-
-	// CompactInterval is interval between database compactions performed by kine.
-	CompactInterval time.Duration
-	// PollInterval is the event poll interval used by kine.
-	PollInterval time.Duration
-	// WatchQueryTimeout is the timeout on the after query in the poll loop.
-	WatchQueryTimeout time.Duration
 }
 
 type ConnectionPoolConfig struct {
@@ -754,25 +747,4 @@ func (d *Generic) GetSize(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 	return size, nil
-}
-
-func (d *Generic) GetCompactInterval() time.Duration {
-	if v := d.CompactInterval; v > 0 {
-		return v
-	}
-	return 5 * time.Minute
-}
-
-func (d *Generic) GetWatchQueryTimeout() time.Duration {
-	if v := d.WatchQueryTimeout; v >= 5*time.Second {
-		return v
-	}
-	return 20 * time.Second
-}
-
-func (d *Generic) GetPollInterval() time.Duration {
-	if v := d.PollInterval; v > 0 {
-		return v
-	}
-	return time.Second
 }

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func New(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (*generic.Generic, error) {
+func NewDriver(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (*generic.Generic, error) {
 	const retryAttempts = 300
 
 	driver, err := generic.Open(ctx, driverName, dataSourceName, connectionPoolConfig)

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -59,7 +59,7 @@ func TestMigration(t *testing.T) {
 		MaxLifetime: 60 * time.Second,
 		MaxIdleTime: 0 * time.Second,
 	}
-	if _, err := sqlite.New(ctx, dbPath, &connPoolConfig); err != nil {
+	if _, err := sqlite.New(ctx, "sqlite3", dbPath, &connPoolConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -59,7 +59,7 @@ func TestMigration(t *testing.T) {
 		MaxLifetime: 60 * time.Second,
 		MaxIdleTime: 0 * time.Second,
 	}
-	if _, err := sqlite.New(ctx, "sqlite3", dbPath, &connPoolConfig); err != nil {
+	if _, err := sqlite.NewDriver(ctx, "sqlite3", dbPath, &connPoolConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -156,7 +156,7 @@ func grpcServer(config Config) *grpc.Server {
 
 func getKineStorageBackend(ctx context.Context, backendType, dsn string, cfg Config) (server.Backend, error) {
 	var (
-		driver sqllog.Dialect
+		driver sqllog.Driver
 		err    error
 	)
 	switch backendType {

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -99,11 +99,11 @@ func createListener(listen string) (_ net.Listener, err error) {
 }
 
 func networkAndAddress(str string) (string, string) {
-	before, after, found := strings.Cut(str, "://")
+	network, address, found := strings.Cut(str, "://")
 	if found {
-		return before, after
+		return network, address
 	}
-	return "", before
+	return "", str
 }
 
 func ListenAndReturnBackend(ctx context.Context, config Config) (ETCDConfig, server.Backend, error) {

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -182,9 +182,9 @@ func getKineStorageBackend(ctx context.Context, config Config) (server.Backend, 
 			}
 			dataSourceName = "./db/state.db?_journal=WAL&_synchronous=FULL&_foreign_keys=1"
 		}
-		driver, err = sqlite.New(ctx, "sqlite3", dataSourceName, &config.ConnectionPoolConfig)
+		driver, err = sqlite.NewDriver(ctx, "sqlite3", dataSourceName, &config.ConnectionPoolConfig)
 	case DQLiteBackend:
-		driver, err = dqlite.New(ctx, options.DriverName, options.DataSourceName, &config.ConnectionPoolConfig)
+		driver, err = dqlite.NewDriver(ctx, options.DriverName, options.DataSourceName, &config.ConnectionPoolConfig)
 	default:
 		return nil, fmt.Errorf("backend type %s is not defined", options.BackendType)
 	}

--- a/pkg/kine/sqllog/sqllog.go
+++ b/pkg/kine/sqllog/sqllog.go
@@ -72,15 +72,6 @@ type SQLLog struct {
 	broadcaster broadcaster.Broadcaster[[]*server.Event]
 	notify      chan int64
 	wg          sync.WaitGroup
-
-	// compactInterval is interval between database compactions performed by kine.
-	compactInterval time.Duration
-
-	// pollInterval is the event poll interval used by kine.
-	pollInterval time.Duration
-
-	// watchQueryTimeout is the timeout on the after query in the poll loop.
-	watchQueryTimeout time.Duration
 }
 
 type SQLLogOptions struct {

--- a/pkg/kine/sqllog/sqllog.go
+++ b/pkg/kine/sqllog/sqllog.go
@@ -42,7 +42,7 @@ func init() {
 	}
 }
 
-type Dialect interface {
+type Driver interface {
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (*sql.Rows, error)
 	ListTTL(ctx context.Context, revision int64) (*sql.Rows, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, error)
@@ -69,13 +69,13 @@ type SQLLog struct {
 	stop    func()
 	started bool
 
-	d           Dialect
+	d           Driver
 	broadcaster broadcaster.Broadcaster[[]*server.Event]
 	notify      chan int64
 	wg          sync.WaitGroup
 }
 
-func New(d Dialect) *SQLLog {
+func New(d Driver) *SQLLog {
 	return &SQLLog{
 		d:      d,
 		notify: make(chan int64, 1024),

--- a/pkg/kine/sqllog/sqllog.go
+++ b/pkg/kine/sqllog/sqllog.go
@@ -58,27 +58,49 @@ type Driver interface {
 	Fill(ctx context.Context, revision int64) error
 	IsFill(key string) bool
 	GetSize(ctx context.Context) (int64, error)
-	GetCompactInterval() time.Duration
-	GetWatchQueryTimeout() time.Duration
-	GetPollInterval() time.Duration
 	Close() error
 }
 
 type SQLLog struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+
+	options *SQLLogOptions
+
 	stop    func()
 	started bool
 
-	d           Driver
 	broadcaster broadcaster.Broadcaster[[]*server.Event]
 	notify      chan int64
 	wg          sync.WaitGroup
+
+	// compactInterval is interval between database compactions performed by kine.
+	compactInterval time.Duration
+
+	// pollInterval is the event poll interval used by kine.
+	pollInterval time.Duration
+
+	// watchQueryTimeout is the timeout on the after query in the poll loop.
+	watchQueryTimeout time.Duration
 }
 
-func New(d Driver) *SQLLog {
+type SQLLogOptions struct {
+	// Driver is the SQL driver to use to query the database.
+	Driver Driver
+
+	// CompactInterval is interval between database compactions performed by kine.
+	CompactInterval time.Duration
+
+	// PollInterval is the event poll interval used by kine.
+	PollInterval time.Duration
+
+	// WatchQueryTimeout is the timeout on the after query in the poll loop.
+	WatchQueryTimeout time.Duration
+}
+
+func New(options *SQLLogOptions) *SQLLog {
 	return &SQLLog{
-		d:      d,
-		notify: make(chan int64, 1024),
+		options: options,
+		notify:  make(chan int64, 1024),
 	}
 }
 
@@ -129,13 +151,13 @@ func (s *SQLLog) Stop() error {
 
 func (s *SQLLog) Close() error {
 	stopErr := s.Stop()
-	closeErr := s.d.Close()
+	closeErr := s.options.Driver.Close()
 
 	return errors.Join(stopErr, closeErr)
 }
 
 func (s *SQLLog) compactStart(ctx context.Context) error {
-	rows, err := s.d.AfterPrefix(ctx, "compact_rev_key", 0, 0)
+	rows, err := s.options.Driver.AfterPrefix(ctx, "compact_rev_key", 0, 0)
 	if err != nil {
 		return err
 	}
@@ -166,7 +188,7 @@ func (s *SQLLog) compactStart(ctx context.Context) error {
 		if event.KV.ModRevision == maxID {
 			continue
 		}
-		if err := s.d.DeleteRevision(ctx, event.KV.ModRevision); err != nil {
+		if err := s.options.Driver.DeleteRevision(ctx, event.KV.ModRevision); err != nil {
 			return err
 		}
 	}
@@ -193,7 +215,7 @@ func (s *SQLLog) DoCompact(ctx context.Context) (err error) {
 	// small batches. Given that this logic runs every second,
 	// on regime it should take usually just a couple batches
 	// to keep the pace.
-	start, target, err := s.d.GetCompactRevision(ctx)
+	start, target, err := s.options.Driver.GetCompactRevision(ctx)
 	if err != nil {
 		return err
 	}
@@ -209,7 +231,7 @@ func (s *SQLLog) DoCompact(ctx context.Context) (err error) {
 		if batchRevision > target {
 			batchRevision = target
 		}
-		if err := s.d.Compact(ctx, batchRevision); err != nil {
+		if err := s.options.Driver.Compact(ctx, batchRevision); err != nil {
 			return err
 		}
 		start = batchRevision
@@ -218,11 +240,11 @@ func (s *SQLLog) DoCompact(ctx context.Context) (err error) {
 }
 
 func (s *SQLLog) CurrentRevision(ctx context.Context) (int64, error) {
-	return s.d.CurrentRevision(ctx)
+	return s.options.Driver.CurrentRevision(ctx)
 }
 
 func (s *SQLLog) GetCompactRevision(ctx context.Context) (int64, int64, error) {
-	return s.d.GetCompactRevision(ctx)
+	return s.options.Driver.GetCompactRevision(ctx)
 }
 
 func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64) (int64, []*server.Event, error) {
@@ -238,7 +260,7 @@ func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64
 		attribute.Int64("limit", limit),
 	)
 
-	compactRevision, currentRevision, err := s.d.GetCompactRevision(ctx)
+	compactRevision, currentRevision, err := s.options.Driver.GetCompactRevision(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -248,7 +270,7 @@ func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64
 		return currentRevision, nil, server.ErrCompacted
 	}
 
-	rows, err := s.d.AfterPrefix(ctx, prefix, revision, limit)
+	rows, err := s.options.Driver.AfterPrefix(ctx, prefix, revision, limit)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -275,7 +297,7 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 		attribute.Int64("revision", revision),
 	)
 
-	compactRevision, currentRevision, err := s.d.GetCompactRevision(ctx)
+	compactRevision, currentRevision, err := s.options.Driver.GetCompactRevision(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -296,7 +318,7 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 		startKey = ""
 	}
 
-	rows, err := s.d.List(ctx, prefix, startKey, limit, revision)
+	rows, err := s.options.Driver.List(ctx, prefix, startKey, limit, revision)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -323,13 +345,13 @@ func (s *SQLLog) ttl(ctx context.Context) {
 	go func() {
 		defer s.wg.Done()
 
-		startRevision, err := s.d.CurrentRevision(ctx)
+		startRevision, err := s.options.Driver.CurrentRevision(ctx)
 		if err != nil {
 			logrus.Errorf("failed to read old events for ttl: %v", err)
 			return
 		}
 
-		rows, err := s.d.ListTTL(ctx, startRevision)
+		rows, err := s.options.Driver.ListTTL(ctx, startRevision)
 		if err != nil {
 			logrus.Errorf("failed to read old events for ttl: %v", err)
 			return
@@ -445,7 +467,7 @@ func (s *SQLLog) startWatch(ctx context.Context) (chan []*server.Event, error) {
 		return nil, err
 	}
 
-	pollStart, _, err := s.d.GetCompactRevision(ctx)
+	pollStart, _, err := s.options.Driver.GetCompactRevision(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +480,7 @@ func (s *SQLLog) startWatch(ctx context.Context) (chan []*server.Event, error) {
 	go func() {
 		defer s.wg.Done()
 
-		t := time.NewTicker(s.d.GetCompactInterval())
+		t := time.NewTicker(s.options.CompactInterval)
 
 		for {
 			select {
@@ -488,7 +510,7 @@ func (s *SQLLog) poll(ctx context.Context, result chan []*server.Event, pollStar
 		waitForMore = true
 	)
 
-	wait := time.NewTicker(s.d.GetPollInterval())
+	wait := time.NewTicker(s.options.PollInterval)
 	defer wait.Stop()
 	defer close(result)
 
@@ -505,10 +527,10 @@ func (s *SQLLog) poll(ctx context.Context, result chan []*server.Event, pollStar
 			}
 		}
 		waitForMore = true
-		watchCtx, cancel := context.WithTimeout(ctx, s.d.GetWatchQueryTimeout())
+		watchCtx, cancel := context.WithTimeout(ctx, s.options.WatchQueryTimeout)
 		defer cancel()
 
-		rows, err := s.d.After(watchCtx, last, pollBatchSize)
+		rows, err := s.options.Driver.After(watchCtx, last, pollBatchSize)
 		if err != nil {
 			if !errors.Is(err, context.DeadlineExceeded) {
 				logrus.Errorf("fail to list latest changes: %v", err)
@@ -552,7 +574,7 @@ func (s *SQLLog) poll(ctx context.Context, result chan []*server.Event, pollStar
 					s.notifyWatcherPoll(next)
 					break
 				} else {
-					if err := s.d.Fill(ctx, next); err == nil {
+					if err := s.options.Driver.Fill(ctx, next); err == nil {
 						logrus.Debugf("FILL, revision=%d, err=%v", next, err)
 						s.notifyWatcherPoll(next)
 					} else {
@@ -569,7 +591,7 @@ func (s *SQLLog) poll(ctx context.Context, result chan []*server.Event, pollStar
 			// the same time we write to the channel.
 			saveLast = true
 			rev = event.KV.ModRevision
-			if s.d.IsFill(event.KV.Key) {
+			if s.options.Driver.IsFill(event.KV.Key) {
 				logrus.Debugf("NOT TRIGGER FILL %s, revision=%d, delete=%v", event.KV.Key, event.KV.ModRevision, event.Delete)
 			} else {
 				sequential = append(sequential, event)
@@ -603,7 +625,7 @@ func (s *SQLLog) Count(ctx context.Context, prefix, startKey string, revision in
 		attribute.Int64("revision", revision),
 	)
 
-	compactRevision, currentRevision, err := s.d.GetCompactRevision(ctx)
+	compactRevision, currentRevision, err := s.options.Driver.GetCompactRevision(ctx)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -612,7 +634,7 @@ func (s *SQLLog) Count(ctx context.Context, prefix, startKey string, revision in
 	} else if revision < compactRevision {
 		return currentRevision, 0, server.ErrCompacted
 	}
-	count, err := s.d.Count(ctx, prefix, startKey, revision)
+	count, err := s.options.Driver.Count(ctx, prefix, startKey, revision)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -620,7 +642,7 @@ func (s *SQLLog) Count(ctx context.Context, prefix, startKey string, revision in
 }
 
 func (s *SQLLog) Create(ctx context.Context, key string, value []byte, lease int64) (int64, bool, error) {
-	rev, created, err := s.d.Create(ctx, key, value, lease)
+	rev, created, err := s.options.Driver.Create(ctx, key, value, lease)
 	if err != nil {
 		return 0, false, err
 	}
@@ -631,7 +653,7 @@ func (s *SQLLog) Create(ctx context.Context, key string, value []byte, lease int
 }
 
 func (s *SQLLog) Delete(ctx context.Context, key string, revision int64) (rev int64, deleted bool, err error) {
-	rev, deleted, err = s.d.Delete(ctx, key, revision)
+	rev, deleted, err = s.options.Driver.Delete(ctx, key, revision)
 	if err != nil {
 		return 0, false, err
 	}
@@ -642,7 +664,7 @@ func (s *SQLLog) Delete(ctx context.Context, key string, revision int64) (rev in
 }
 
 func (s *SQLLog) Update(ctx context.Context, key string, value []byte, prevRev, lease int64) (rev int64, updated bool, err error) {
-	rev, updated, err = s.d.Update(ctx, key, value, prevRev, lease)
+	rev, updated, err = s.options.Driver.Update(ctx, key, value, prevRev, lease)
 	if err != nil {
 		return 0, false, err
 	}
@@ -666,7 +688,7 @@ func (s *SQLLog) DbSize(ctx context.Context) (int64, error) {
 		span.RecordError(err)
 		span.End()
 	}()
-	size, err := s.d.GetSize(ctx)
+	size, err := s.options.Driver.GetSize(ctx)
 	span.SetAttributes(attribute.Int64("size", size))
 	return size, err
 }


### PR DESCRIPTION
This PR moves the instantiation of `SQLLog` away from the `drivers` folder as it is not a drivers concern to decide how they should be used.

It also renames `Dialect` to `Driver` to match naming.