### PR TITLE
Remove TranslateErr from Generic

### DIFF
--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -71,12 +71,6 @@ func NewVariant(ctx context.Context, datasourceName string, connectionPoolConfig
 
 		return false
 	}
-	generic.TranslateErr = func(err error) error {
-		if strings.Contains(err.Error(), "UNIQUE constraint") {
-			return server.ErrKeyExists
-		}
-		return err
-	}
 
 	return backend, generic, nil
 }

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -235,17 +235,15 @@ func (s Stripped) String() string {
 }
 
 type ErrRetry func(error) bool
-type TranslateErr func(error) error
 type ErrCode func(error) string
 
 type Generic struct {
 	sync.Mutex
 
-	LockWrites   bool
-	DB           *prepared.DB
-	Retry        ErrRetry
-	TranslateErr TranslateErr
-	ErrCode      ErrCode
+	LockWrites bool
+	DB         *prepared.DB
+	Retry      ErrRetry
+	ErrCode    ErrCode
 
 	// CompactInterval is interval between database compactions performed by kine.
 	CompactInterval time.Duration
@@ -451,12 +449,7 @@ func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int6
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Create", otelName))
 
 	defer func() {
-		if err != nil {
-			if d.TranslateErr != nil {
-				err = d.TranslateErr(err)
-			}
-			span.RecordError(err)
-		}
+		span.RecordError(err)
 		span.SetAttributes(attribute.Int64("revision", rev))
 		span.End()
 	}()
@@ -483,12 +476,7 @@ func (d *Generic) Create(ctx context.Context, key string, value []byte, ttl int6
 func (d *Generic) Update(ctx context.Context, key string, value []byte, preRev, ttl int64) (rev int64, updated bool, err error) {
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Update", otelName))
 	defer func() {
-		if err != nil {
-			if d.TranslateErr != nil {
-				err = d.TranslateErr(err)
-			}
-			span.RecordError(err)
-		}
+		span.RecordError(err)
 		span.End()
 	}()
 

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -77,13 +77,6 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connecti
 		time.Sleep(time.Second)
 	}
 
-	dialect.TranslateErr = func(err error) error {
-		if err, ok := err.(sqlite3.Error); ok && err.ExtendedCode == sqlite3.ErrConstraintUnique {
-			return server.ErrKeyExists
-		}
-		return err
-	}
-
 	dialect.CompactInterval = opts.compactInterval
 	dialect.PollInterval = opts.pollInterval
 	dialect.WatchQueryTimeout = opts.watchQueryTimeout

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -7,7 +7,6 @@ import (
 )
 
 var (
-	ErrKeyExists     = rpctypes.ErrGRPCDuplicateKey
 	ErrCompacted     = rpctypes.ErrGRPCCompacted
 	ErrGRPCUnhealthy = rpctypes.ErrGRPCUnhealthy
 )


### PR DESCRIPTION
This PR removes `TranslateErr` from `Generic` as that was a goofy way to return `ErrKeyExists` to the server.

We are now managing that by explicitly returning a bool from transactions. Also our queries do not fail any more, but they just don't insert anything (which is a requirement for batching).