### PR TITLE
pytest: log timestamps

### DIFF
--- a/test/performance/tox.ini
+++ b/test/performance/tox.ini
@@ -37,6 +37,8 @@ commands =
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
+        --log-format "%(asctime)s %(levelname)s %(message)s" \
+        --log-date-format "%Y-%m-%d %H:%M:%S" \
         --disable-warnings \
         {posargs} \
         {toxinidir}/tests


### PR DESCRIPTION
The CI job duration increased significantly after switching to self-hosted runners.

We'll update the pytest invocation to log timestamps, which should help us uncover potential bottlenecks.

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
