### PR TITLE
refactor: remove `generic` package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
+	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	"github.com/canonical/k8s-dqlite/pkg/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -33,7 +33,7 @@ var (
 		otel                   bool
 		otelAddress            string
 
-		connectionPoolConfig sqlite.ConnectionPoolConfig
+		connectionPoolConfig *endpoint.ConnectionPoolConfig
 
 		watchAvailableStorageInterval time.Duration
 		watchAvailableStorageMinBytes uint64

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
+	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -33,7 +33,7 @@ var (
 		otel                   bool
 		otelAddress            string
 
-		connectionPoolConfig generic.ConnectionPoolConfig
+		connectionPoolConfig sqlite.ConnectionPoolConfig
 
 		watchAvailableStorageInterval time.Duration
 		watchAvailableStorageMinBytes uint64

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	"github.com/canonical/k8s-dqlite/pkg/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -33,7 +32,7 @@ var (
 		otel                   bool
 		otelAddress            string
 
-		connectionPoolConfig *endpoint.ConnectionPoolConfig
+		connectionPoolConfig server.ConnectionPoolConfig
 
 		watchAvailableStorageInterval time.Duration
 		watchAvailableStorageMinBytes uint64
@@ -105,7 +104,7 @@ var (
 				rootCmdOpts.watchAvailableStorageInterval,
 				rootCmdOpts.watchAvailableStorageMinBytes,
 				rootCmdOpts.lowAvailableStorageAction,
-				rootCmdOpts.connectionPoolConfig,
+				&rootCmdOpts.connectionPoolConfig,
 				rootCmdOpts.watchQueryTimeout,
 				rootCmdOpts.watchProgressNotifyInterval,
 			)

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -24,16 +24,16 @@ func init() {
 
 type Driver = sqlite.Driver
 
-type DriverOptions struct {
+type DriverConfig struct {
 	DB      database.Interface
 	ErrCode func(error) string
 }
 
-func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
+func NewDriver(ctx context.Context, config *DriverConfig) (*Driver, error) {
 	logrus.Printf("New driver for dqlite")
 
-	drv, err := sqlite.NewDriver(ctx, &sqlite.DriverOptions{
-		DB:         options.DB,
+	drv, err := sqlite.NewDriver(ctx, &sqlite.DriverConfig{
+		DB:         config.DB,
 		LockWrites: true,
 		Retry:      dqliteRetry,
 	})
@@ -41,7 +41,7 @@ func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
 		return nil, err
 	}
 
-	if err := migrate(ctx, options.DB); err != nil {
+	if err := migrate(ctx, config.DB); err != nil {
 		return nil, errors.Wrap(err, "failed to migrate DB from sqlite")
 	}
 

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -30,7 +30,7 @@ type DriverOptions struct {
 }
 
 func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
-	logrus.Printf("New kine for dqlite")
+	logrus.Printf("New driver for dqlite")
 
 	drv, err := sqlite.NewDriver(ctx, &sqlite.DriverOptions{
 		DB:         options.DB,

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/canonical/go-dqlite/v2"
 	"github.com/canonical/go-dqlite/v2/driver"
+	"github.com/canonical/k8s-dqlite/pkg/database"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
-	"github.com/canonical/k8s-dqlite/pkg/kine/sqllog"
 	"github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -22,69 +22,74 @@ func init() {
 	}
 }
 
-func NewDriver(ctx context.Context, driverName, datasourceName string, connectionPoolConfig *sqlite.ConnectionPoolConfig) (sqllog.Driver, error) {
+type Driver = sqlite.Driver
+
+type DriverOptions struct {
+	DB      database.Interface
+	ErrCode func(error) string
+}
+
+func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
 	logrus.Printf("New kine for dqlite")
 
-	driver_, err := sqlite.NewDriver(ctx, driverName, datasourceName, connectionPoolConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "sqlite client")
-	}
-
-	conn, err := driver_.DB.Conn(ctx)
+	drv, err := sqlite.NewDriver(ctx, &sqlite.DriverOptions{
+		DB:         options.DB,
+		LockWrites: true,
+		Retry:      dqliteRetry,
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
-	if err := migrate(ctx, conn); err != nil {
+	if err := migrate(ctx, options.DB); err != nil {
 		return nil, errors.Wrap(err, "failed to migrate DB from sqlite")
 	}
-	driver_.LockWrites = true
-	driver_.Retry = func(err error) bool {
-		// get the inner-most error if possible
-		err = errors.Cause(err)
 
-		if err, ok := err.(driver.Error); ok {
-			return err.Code == driver.ErrBusy
-		}
-
-		if err == sqlite3.ErrLocked || err == sqlite3.ErrBusy {
-			return true
-		}
-
-		if strings.Contains(err.Error(), "database is locked") {
-			return true
-		}
-
-		if strings.Contains(err.Error(), "cannot start a transaction within a transaction") {
-			return true
-		}
-
-		if strings.Contains(err.Error(), "bad connection") {
-			return true
-		}
-
-		if strings.Contains(err.Error(), "checkpoint in progress") {
-			return true
-		}
-
-		return false
-	}
-
-	return driver_, nil
+	return drv, nil
 }
 
-func migrate(ctx context.Context, newDB *sql.Conn) (exitErr error) {
-	row := newDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM kine")
-	var count int64
-	if err := row.Scan(&count); err != nil {
-		return err
-	}
-	if count > 0 {
-		return nil
+func dqliteRetry(err error) bool {
+	// get the inner-most error if possible
+	err = errors.Cause(err)
+
+	if err, ok := err.(driver.Error); ok {
+		return err.Code == driver.ErrBusy
 	}
 
-	if _, err := os.Stat("./db/state.db"); err != nil {
+	if err == sqlite3.ErrLocked || err == sqlite3.ErrBusy {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "database is locked") {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "cannot start a transaction within a transaction") {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "bad connection") {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "checkpoint in progress") {
+		return true
+	}
+
+	return false
+}
+
+// FIXME this might be very slow.
+func migrate(ctx context.Context, db database.Interface) (exitErr error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if migrate, err := shouldMigrate(ctx, conn); err != nil {
+		return err
+	} else if !migrate {
 		return nil
 	}
 
@@ -94,50 +99,65 @@ func migrate(ctx context.Context, newDB *sql.Conn) (exitErr error) {
 	}
 	defer oldDB.Close()
 
-	oldData, err := oldDB.QueryContext(ctx, "SELECT id, name, created, deleted, create_revision, prev_revision, lease, value, old_value FROM kine")
+	oldData, err := oldDB.QueryContext(ctx, `
+SELECT id, name, created, deleted, create_revision, prev_revision, lease, value, old_value
+FROM kine
+ORDER BY id ASC`)
 	if err != nil {
 		logrus.Errorf("failed to find old data to migrate: %v", err)
 		return nil
 	}
 	defer oldData.Close()
 
-	tx, err := newDB.BeginTx(ctx, nil)
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if exitErr == nil {
-			exitErr = tx.Commit()
-		} else {
-			tx.Rollback()
-		}
-	}()
+	defer tx.Rollback()
 
+	stmt, err := tx.PrepareContext(ctx, `
+INSERT INTO kine(id, name, created, deleted, create_revision, prev_revision, lease, value, old_value)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	oldRow := []interface{}{
+		new(int),
+		new(string),
+		new(int),
+		new(int),
+		new(int),
+		new(int),
+		new(int),
+		new([]byte),
+		new([]byte),
+	}
 	for oldData.Next() {
-		row := []interface{}{
-			new(int),
-			new(string),
-			new(int),
-			new(int),
-			new(int),
-			new(int),
-			new(int),
-			new([]byte),
-			new([]byte),
-		}
-		if err := oldData.Scan(row...); err != nil {
+		if err := oldData.Scan(oldRow...); err != nil {
 			return err
 		}
 
-		if _, err := newDB.ExecContext(ctx, "INSERT INTO kine(id, name, created, deleted, create_revision, prev_revision, lease, value, old_value) values(?, ?, ?, ?, ?, ?, ?, ?, ?)",
-			row...); err != nil {
+		if _, err := stmt.ExecContext(ctx, oldRow...); err != nil {
 			return err
 		}
 	}
-
 	if err := oldData.Err(); err != nil {
 		return err
 	}
 
-	return nil
+	return tx.Commit()
+}
+
+func shouldMigrate(ctx context.Context, conn *sql.Conn) (bool, error) {
+	if _, err := os.Stat("./db/state.db"); err != nil {
+		return false, nil
+	}
+
+	row := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM kine")
+	var count int64
+	if err := row.Scan(&count); err != nil {
+		return false, err
+	}
+	return count == 0, nil
 }

--- a/pkg/kine/drivers/dqlite/dqlite.go
+++ b/pkg/kine/drivers/dqlite/dqlite.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/canonical/go-dqlite/v2"
 	"github.com/canonical/go-dqlite/v2/driver"
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/sqllog"
 	"github.com/mattn/go-sqlite3"
@@ -23,7 +22,7 @@ func init() {
 	}
 }
 
-func NewDriver(ctx context.Context, driverName, datasourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (sqllog.Driver, error) {
+func NewDriver(ctx context.Context, driverName, datasourceName string, connectionPoolConfig *sqlite.ConnectionPoolConfig) (sqllog.Driver, error) {
 	logrus.Printf("New kine for dqlite")
 
 	driver_, err := sqlite.NewDriver(ctx, driverName, datasourceName, connectionPoolConfig)

--- a/pkg/kine/drivers/sqlite/generic.go
+++ b/pkg/kine/drivers/sqlite/generic.go
@@ -1,4 +1,4 @@
-package generic
+package sqlite
 
 import (
 	"context"

--- a/pkg/kine/drivers/sqlite/metrics.go
+++ b/pkg/kine/drivers/sqlite/metrics.go
@@ -43,14 +43,6 @@ func recordOpResult(txName string, err error, startTime time.Time) {
 	metricsOpResult.WithLabelValues(txName, resultLabel).Inc()
 }
 
-func incCurrentOps(txName string) {
-	metricsCurrentOps.WithLabelValues(txName).Inc()
-}
-
-func decCurrentOps(txName string) {
-	metricsCurrentOps.WithLabelValues(txName).Dec()
-}
-
 func init() {
 	prometheus.MustRegister(
 		metricsTxResult,

--- a/pkg/kine/drivers/sqlite/metrics.go
+++ b/pkg/kine/drivers/sqlite/metrics.go
@@ -1,4 +1,4 @@
-package generic
+package sqlite
 
 import (
 	"time"

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewDriver(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *ConnectionPoolConfig) (*Generic, error) {
+func NewDriver(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *ConnectionPoolConfig) (*Driver, error) {
 	const retryAttempts = 300
 
 	driver, err := Open(ctx, driverName, dataSourceName, connectionPoolConfig)

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -12,20 +12,20 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
+func NewDriver(ctx context.Context, config *DriverConfig) (*Driver, error) {
 	const retryAttempts = 300
 
-	if options == nil {
+	if config == nil {
 		return nil, errors.New("options cannot be nil")
 	}
-	if options.DB == nil {
+	if config.DB == nil {
 		return nil, errors.New("db cannot be nil")
 	}
-	if options.ErrCode == nil {
-		options.ErrCode = error.Error
+	if config.ErrCode == nil {
+		config.ErrCode = error.Error
 	}
-	if options.Retry == nil {
-		options.Retry = func(err error) bool {
+	if config.Retry == nil {
+		config.Retry = func(err error) bool {
 			if err, ok := err.(sqlite3.Error); ok {
 				return err.Code == sqlite3.ErrBusy
 			}
@@ -34,7 +34,7 @@ func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
 	}
 
 	for i := 0; i < retryAttempts; i++ {
-		err := setup(ctx, options.DB)
+		err := setup(ctx, config.DB)
 		if err == nil {
 			break
 		}
@@ -47,7 +47,7 @@ func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
 	}
 
 	return &Driver{
-		options: options,
+		config: config,
 	}, nil
 }
 

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -6,16 +6,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-func NewDriver(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *generic.ConnectionPoolConfig) (*generic.Generic, error) {
+func NewDriver(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *ConnectionPoolConfig) (*Generic, error) {
 	const retryAttempts = 300
 
-	driver, err := generic.Open(ctx, driverName, dataSourceName, connectionPoolConfig)
+	driver, err := Open(ctx, driverName, dataSourceName, connectionPoolConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kine/drivers/sqlite/sqlite.go
+++ b/pkg/kine/drivers/sqlite/sqlite.go
@@ -6,27 +6,35 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/canonical/k8s-dqlite/pkg/database"
 	"github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-func NewDriver(ctx context.Context, driverName, dataSourceName string, connectionPoolConfig *ConnectionPoolConfig) (*Driver, error) {
+func NewDriver(ctx context.Context, options *DriverOptions) (*Driver, error) {
 	const retryAttempts = 300
 
-	driver, err := Open(ctx, driverName, dataSourceName, connectionPoolConfig)
-	if err != nil {
-		return nil, err
+	if options == nil {
+		return nil, errors.New("options cannot be nil")
 	}
-	for i := 0; i < retryAttempts; i++ {
-		err = func() error {
-			conn, err := driver.DB.Conn(ctx)
-			if err != nil {
-				return err
+	if options.DB == nil {
+		return nil, errors.New("db cannot be nil")
+	}
+	if options.ErrCode == nil {
+		options.ErrCode = error.Error
+	}
+	if options.Retry == nil {
+		options.Retry = func(err error) bool {
+			if err, ok := err.(sqlite3.Error); ok {
+				return err.Code == sqlite3.ErrBusy
 			}
-			defer conn.Close()
-			return setup(ctx, conn)
-		}()
+			return false
+		}
+	}
+
+	for i := 0; i < retryAttempts; i++ {
+		err := setup(ctx, options.DB)
 		if err == nil {
 			break
 		}
@@ -36,30 +44,28 @@ func NewDriver(ctx context.Context, driverName, dataSourceName string, connectio
 			return nil, ctx.Err()
 		case <-time.After(time.Second):
 		}
-		time.Sleep(time.Second)
 	}
 
-	if driverName == "sqlite3" {
-		driver.Retry = func(err error) bool {
-			if err, ok := err.(sqlite3.Error); ok {
-				return err.Code == sqlite3.ErrBusy
-			}
-			return false
-		}
-	}
-
-	return driver, nil
+	return &Driver{
+		options: options,
+	}, nil
 }
 
 // setup performs table setup, which may include creation of the Kine table if
 // it doesn't already exist, migrating key_value table contents to the Kine
 // table if the key_value table exists, all in a single database transaction.
 // changes are rolled back if an error occurs.
-func setup(ctx context.Context, db *sql.Conn) error {
+func setup(ctx context.Context, db database.Interface) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
 	// Optimistically ask for the user_version without starting a transaction
 	var currentSchemaVersion SchemaVersion
 
-	row := db.QueryRowContext(ctx, `PRAGMA user_version`)
+	row := conn.QueryRowContext(ctx, `PRAGMA user_version`)
 	if err := row.Scan(&currentSchemaVersion); err != nil {
 		return err
 	}
@@ -71,7 +77,7 @@ func setup(ctx context.Context, db *sql.Conn) error {
 		return nil
 	}
 
-	txn, err := db.BeginTx(ctx, nil)
+	txn, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -51,7 +51,7 @@ func TestMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlite.NewDriver(context.Background(), &sqlite.DriverOptions{
+	if _, err := sqlite.NewDriver(context.Background(), &sqlite.DriverConfig{
 		DB: database.NewPrepared(db),
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"path"
 	"testing"
-	"time"
 
+	"github.com/canonical/k8s-dqlite/pkg/database"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/sirupsen/logrus"
 )
@@ -51,14 +51,9 @@ func TestMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
-	connPoolConfig := sqlite.ConnectionPoolConfig{
-		MaxIdle:     5,
-		MaxOpen:     5,
-		MaxLifetime: 60 * time.Second,
-		MaxIdleTime: 0 * time.Second,
-	}
-	if _, err := sqlite.NewDriver(ctx, "sqlite3", dbPath, &connPoolConfig); err != nil {
+	if _, err := sqlite.NewDriver(context.Background(), &sqlite.DriverOptions{
+		DB: database.NewPrepared(db),
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kine/drivers/sqlite/sqlite_test.go
+++ b/pkg/kine/drivers/sqlite/sqlite_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/sirupsen/logrus"
 )
@@ -53,7 +52,7 @@ func TestMigration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	connPoolConfig := generic.ConnectionPoolConfig{
+	connPoolConfig := sqlite.ConnectionPoolConfig{
 		MaxIdle:     5,
 		MaxOpen:     5,
 		MaxLifetime: 60 * time.Second,

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/dqlite"
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
 	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	"github.com/canonical/k8s-dqlite/pkg/kine/sqllog"
@@ -33,7 +32,8 @@ type Config struct {
 	GRPCServer           *grpc.Server
 	Listener             string
 	Endpoint             string
-	ConnectionPoolConfig generic.ConnectionPoolConfig
+	ConnectionPoolConfig sqlite.ConnectionPoolConfig
+
 	tls.Config
 	NotifyInterval time.Duration
 }

--- a/pkg/kine/endpoint/endpoint.go
+++ b/pkg/kine/endpoint/endpoint.go
@@ -2,114 +2,87 @@ package endpoint
 
 import (
 	"context"
-	"database/sql"
-	"fmt"
 	"net"
-	"net/url"
 	"os"
-	"path"
 	"strings"
-	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/database"
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/dqlite"
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
-	"github.com/canonical/k8s-dqlite/pkg/kine/server"
-	"github.com/canonical/k8s-dqlite/pkg/kine/sqllog"
 	"github.com/canonical/k8s-dqlite/pkg/kine/tls"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/server/v3/embed"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 )
 
 const (
-	KineSocket          = "unix://kine.sock"
-	SQLiteBackend       = "sqlite"
-	DQLiteBackend       = "dqlite"
-	defaultMaxIdleConns = 2 // default from database/sql
+	KineSocket = "unix://kine.sock"
 )
-
-type Config struct {
-	GRPCServer           *grpc.Server
-	Listener             string
-	Endpoint             string
-	ConnectionPoolConfig *ConnectionPoolConfig
-
-	tls.Config
-	NotifyInterval time.Duration
-}
-
-type ConnectionPoolConfig struct {
-	MaxIdle     int
-	MaxOpen     int
-	MaxLifetime time.Duration
-	MaxIdleTime time.Duration
-}
-
-func (conf *ConnectionPoolConfig) apply(db *sql.DB) {
-	// behavior of database/sql - zero means defaultMaxIdleConns; negative means 0
-	var maxIdle int
-	if conf.MaxIdle < 0 {
-		maxIdle = 0
-	} else if conf.MaxIdle == 0 {
-		maxIdle = defaultMaxIdleConns
-	}
-
-	logrus.Infof(
-		"Configuring database connection pooling: maxIdleConns=%d, maxOpenConns=%d, connMaxLifetime=%v, connMaxIdleTime=%v ",
-		maxIdle,
-		conf.MaxOpen,
-		conf.MaxLifetime,
-		conf.MaxIdleTime,
-	)
-	db.SetMaxIdleConns(conf.MaxIdle)
-	db.SetMaxOpenConns(conf.MaxOpen)
-	db.SetConnMaxLifetime(conf.MaxLifetime)
-	db.SetConnMaxIdleTime(conf.MaxIdleTime)
-}
 
 type ETCDConfig struct {
 	Endpoints []string
 	TLSConfig tls.Config
 }
 
-func Listen(ctx context.Context, config *Config) (ETCDConfig, error) {
-	backend, err := openKineStorageBackend(ctx, config)
+type Server interface {
+	etcdserverpb.LeaseServer
+	etcdserverpb.WatchServer
+	etcdserverpb.KVServer
+	etcdserverpb.MaintenanceServer
+}
+
+type EndpointOptions struct {
+	ListenAddress string
+
+	Server Server
+}
+
+func Listen(ctx context.Context, options *EndpointOptions) (*ETCDConfig, error) {
+	grpcServer := grpc.NewServer(
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             embed.DefaultGRPCKeepAliveMinTime,
+			PermitWithoutStream: false,
+		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    embed.DefaultGRPCKeepAliveInterval,
+			Timeout: embed.DefaultGRPCKeepAliveTimeout,
+		}),
+	)
+	registerServer(grpcServer, options.Server)
+
+	listenAddress := options.ListenAddress
+	if listenAddress == "" {
+		listenAddress = KineSocket
+	}
+	listener, err := createListener(listenAddress)
 	if err != nil {
-		return ETCDConfig{}, errors.Wrap(err, "building kine")
-	}
-
-	if err := backend.Start(ctx); err != nil {
-		return ETCDConfig{}, errors.Wrap(err, "starting kine backend")
-	}
-
-	listen := config.Listener
-	if listen == "" {
-		listen = KineSocket
-	}
-
-	b := server.New(backend, config.NotifyInterval)
-	grpcServer := grpcServer(config)
-	b.Register(grpcServer)
-
-	listener, err := createListener(listen)
-	if err != nil {
-		return ETCDConfig{}, err
+		return nil, err
 	}
 
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			logrus.Errorf("unexpected server shutdown: %v", err)
+			logrus.Errorf("Kine server shutdown: %v", err)
 		}
+		listener.Close()
 	}()
 	context.AfterFunc(ctx, grpcServer.Stop)
 
-	return ETCDConfig{
-		Endpoints: []string{listen},
+	return &ETCDConfig{
+		Endpoints: []string{listenAddress},
 		TLSConfig: tls.Config{},
 	}, nil
+}
+
+func registerServer(grpc *grpc.Server, server Server) {
+	etcdserverpb.RegisterLeaseServer(grpc, server)
+	etcdserverpb.RegisterWatchServer(grpc, server)
+	etcdserverpb.RegisterKVServer(grpc, server)
+	etcdserverpb.RegisterMaintenanceServer(grpc, server)
+
+	hsrv := health.NewServer()
+	hsrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(grpc, hsrv)
 }
 
 func createListener(listen string) (_ net.Listener, err error) {
@@ -136,242 +109,4 @@ func networkAndAddress(str string) (string, string) {
 		return network, address
 	}
 	return "", str
-}
-
-func ListenAndReturnBackend(ctx context.Context, config *Config) (ETCDConfig, server.Backend, error) {
-	backend, err := openKineStorageBackend(ctx, config)
-	if err != nil {
-		return ETCDConfig{}, nil, errors.Wrap(err, "building kine")
-	}
-
-	if err := backend.Start(ctx); err != nil {
-		return ETCDConfig{}, nil, errors.Wrap(err, "starting kine backend")
-	}
-
-	listen := config.Listener
-	if listen == "" {
-		listen = KineSocket
-	}
-
-	b := server.New(backend, config.NotifyInterval)
-	grpcServer := grpcServer(config)
-	b.Register(grpcServer)
-
-	listener, err := createListener(listen)
-	if err != nil {
-		return ETCDConfig{}, nil, err
-	}
-
-	go func() {
-		if err := grpcServer.Serve(listener); err != nil {
-			logrus.Errorf("Kine server shutdown: %v", err)
-		}
-		listener.Close()
-	}()
-	context.AfterFunc(ctx, grpcServer.Stop)
-
-	return ETCDConfig{
-		Endpoints: []string{listen},
-		TLSConfig: tls.Config{},
-	}, backend, nil
-}
-
-func grpcServer(config *Config) *grpc.Server {
-	if config.GRPCServer != nil {
-		return config.GRPCServer
-	}
-	gopts := []grpc.ServerOption{
-		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             embed.DefaultGRPCKeepAliveMinTime,
-			PermitWithoutStream: false,
-		}),
-		grpc.KeepaliveParams(keepalive.ServerParameters{
-			Time:    embed.DefaultGRPCKeepAliveInterval,
-			Timeout: embed.DefaultGRPCKeepAliveTimeout,
-		}),
-	}
-
-	return grpc.NewServer(gopts...)
-}
-
-func openKineStorageBackend(ctx context.Context, config *Config) (server.Backend, error) {
-	var (
-		driver sqllog.Driver
-		err    error
-	)
-
-	options, err := parseOpts(config.Endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	switch options.BackendType {
-	case SQLiteBackend:
-		driver, err = openSqlite(ctx, options.DataSourceName, config.ConnectionPoolConfig)
-	case DQLiteBackend:
-		driver, err = openDqlite(ctx, options.DriverName, options.DataSourceName, config.ConnectionPoolConfig)
-	default:
-		return nil, fmt.Errorf("backend type %s is not defined", options.BackendType)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return sqllog.New(&sqllog.SQLLogOptions{
-		Driver:            driver,
-		CompactInterval:   options.CompactInterval,
-		PollInterval:      options.PollInterval,
-		WatchQueryTimeout: options.WatchQueryTimeout,
-	}), err
-}
-
-func openSqlite(ctx context.Context, dataSourceName string, connPoolConfig *ConnectionPoolConfig) (sqllog.Driver, error) {
-	if dataSourceName == "" {
-		if err := os.MkdirAll("./db", 0700); err != nil {
-			return nil, err
-		}
-		dataSourceName = "./db/state.db?_journal=WAL&_synchronous=FULL&_foreign_keys=1"
-	}
-	db, err := sql.Open("sqlite3", dataSourceName)
-	if err != nil {
-		return nil, err
-	}
-	if connPoolConfig != nil {
-		connPoolConfig.apply(db)
-	}
-
-	return sqlite.NewDriver(ctx, &sqlite.DriverOptions{
-		DB: database.NewPrepared(db),
-	})
-}
-
-func openDqlite(ctx context.Context, driverName, dataSourceName string, connPoolConfig *ConnectionPoolConfig) (sqllog.Driver, error) {
-	var (
-		db  *sql.DB
-		err error
-	)
-	for i := 0; i < 300; i++ {
-		db, err = openAndTest(ctx, driverName, dataSourceName)
-		if err == nil {
-			break
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(time.Second):
-		}
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	if connPoolConfig != nil {
-		connPoolConfig.apply(db)
-	}
-
-	return dqlite.NewDriver(ctx, &dqlite.DriverOptions{
-		DB: database.NewPrepared(db),
-	})
-}
-
-func openAndTest(ctx context.Context, driverName, dataSourceName string) (*sql.DB, error) {
-	db, err := sql.Open(driverName, dataSourceName)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := db.PingContext(ctx); err != nil {
-		logrus.Errorf("failed to ping connection: %v", err)
-		db.Close()
-		return nil, err
-	}
-
-	return db, nil
-}
-
-type backendOptions struct {
-	// BackendType is the type of backend to use.
-	BackendType string
-
-	// DriverName is the name of the database driver.
-	DriverName string
-
-	// DataSourceName is the uri for the database file.
-	DataSourceName string
-
-	CompactInterval   time.Duration
-	PollInterval      time.Duration
-	WatchQueryTimeout time.Duration
-}
-
-func parseOpts(rawUri string) (*backendOptions, error) {
-	uri, err := url.Parse(rawUri)
-	if err != nil {
-		return nil, err
-	}
-
-	// The configuration of kine uses the schema as the
-	// driver name. However that forces the URL to be
-	// absolute, while using a relative path. As such,
-	// the host, if present, should actually be part
-	// of the path.
-	uri.Path = path.Join(uri.Host, uri.Path)
-	uri.Host = ""
-
-	options, err := url.ParseQuery(uri.RawQuery)
-	if err != nil {
-		return nil, err
-	}
-
-	backendType := uri.Scheme
-	if backendType == "" {
-		backendType = SQLiteBackend
-	}
-
-	driverName := options.Get("driver-name")
-	options.Del("driver-name")
-
-	getDuration := func(name string, defaultValue time.Duration) (time.Duration, error) {
-		defer options.Del(name)
-
-		value := options.Get(name)
-		if value == "" {
-			return defaultValue, nil
-		}
-		duration, err := time.ParseDuration(value)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse compact-interval duration value %q: %w", value, err)
-		}
-		return duration, nil
-	}
-
-	compactInterval, err := getDuration("compact-interval", 5*time.Minute)
-	if err != nil {
-		return nil, err
-	}
-
-	pollInterval, err := getDuration("poll-interval", 1*time.Second)
-	if err != nil {
-		return nil, err
-	}
-
-	watchQueryTimeout, err := getDuration("watch-query-timeout", 20*time.Second)
-	if err != nil {
-		return nil, err
-	}
-
-	dataSource := &url.URL{
-		Path:     uri.Path,
-		RawQuery: options.Encode(),
-	}
-
-	return &backendOptions{
-		BackendType:       backendType,
-		DataSourceName:    dataSource.String(),
-		DriverName:        driverName,
-		CompactInterval:   compactInterval,
-		PollInterval:      pollInterval,
-		WatchQueryTimeout: watchQueryTimeout,
-	}, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/canonical/go-dqlite/v2"
 	"github.com/canonical/go-dqlite/v2/app"
 	"github.com/canonical/go-dqlite/v2/client"
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	kine_tls "github.com/canonical/k8s-dqlite/pkg/kine/tls"
@@ -28,7 +27,7 @@ type Server struct {
 	backend server.Backend
 
 	// kineConfig is the configuration to use for starting kine against the dqlite application.
-	kineConfig endpoint.Config
+	kineConfig *endpoint.Config
 
 	// storageDir is the root directory used for dqlite storage.
 	storageDir string
@@ -74,7 +73,7 @@ func New(
 	watchAvailableStorageInterval time.Duration,
 	watchAvailableStorageMinBytes uint64,
 	lowAvailableStorageAction string,
-	connectionPoolConfig sqlite.ConnectionPoolConfig,
+	connectionPoolConfig *endpoint.ConnectionPoolConfig,
 	watchQueryTimeout time.Duration,
 	watchProgressNotifyInterval time.Duration,
 
@@ -312,7 +311,7 @@ func New(
 
 	return &Server{
 		app:        app,
-		kineConfig: kineConfig,
+		kineConfig: &kineConfig,
 
 		storageDir:                    dir,
 		watchAvailableStorageMinBytes: watchAvailableStorageMinBytes,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -413,7 +413,7 @@ func (s *Server) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 
-	driver, err := dqliteDriver.NewDriver(ctx, &dqliteDriver.DriverOptions{
+	driver, err := dqliteDriver.NewDriver(ctx, &dqliteDriver.DriverConfig{
 		DB: database.NewPrepared(db),
 	})
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -406,7 +406,7 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	logrus.WithFields(logrus.Fields{"id": s.app.ID(), "address": s.app.Address()}).Print("Started dqlite")
 
-	logrus.WithField("config", s.serverConfig).Debug("Starting kine")
+	logrus.WithField("config", s.serverConfig).Debug("Starting k8s-dqlite server")
 
 	db, err := s.robustOpenDb(ctx)
 	if err != nil {
@@ -443,7 +443,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	go s.watchAvailableStorageSize(ctx)
 
-	logrus.WithField("address", s.serverConfig.ListenAddress).Print("Started kine")
+	logrus.WithField("address", s.serverConfig.ListenAddress).Print("Started k8s-dqlite server")
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,7 +29,6 @@ type Server struct {
 
 	backend server.Backend
 
-	// serverConfig is the configuration to use for starting kine against the dqlite application.
 	serverConfig         *ServerConfig
 	connectionPoolConfig *ConnectionPoolConfig
 
@@ -486,37 +485,6 @@ func (s *Server) openAndTestDb(ctx context.Context) (*sql.DB, error) {
 
 	return db, nil
 }
-
-// func openKineStorageBackend(ctx context.Context, config *Config) (server.Backend, error) {
-// 	var (
-// 		driver sqllog.Driver
-// 		err    error
-// 	)
-
-// 	options, err := parseOpts(config.Endpoint)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	switch options.BackendType {
-// 	case SQLiteBackend:
-// 		driver, err = openSqlite(ctx, options.DataSourceName, config.ConnectionPoolConfig)
-// 	case DQLiteBackend:
-// 		driver, err = openDqlite(ctx, options.DriverName, options.DataSourceName, config.ConnectionPoolConfig)
-// 	default:
-// 		return nil, fmt.Errorf("backend type %s is not defined", options.BackendType)
-// 	}
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	return sqllog.New(&sqllog.SQLLogOptions{
-// 		Driver:            driver,
-// 		CompactInterval:   options.CompactInterval,
-// 		PollInterval:      options.PollInterval,
-// 		WatchQueryTimeout: options.WatchQueryTimeout,
-// 	}), err
-// }
 
 // Shutdown cleans up any resources and attempts to hand-over and shutdown the dqlite application.
 func (s *Server) Shutdown(ctx context.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/canonical/go-dqlite/v2"
 	"github.com/canonical/go-dqlite/v2/app"
 	"github.com/canonical/go-dqlite/v2/client"
-	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/generic"
+	"github.com/canonical/k8s-dqlite/pkg/kine/drivers/sqlite"
 	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
 	kine_tls "github.com/canonical/k8s-dqlite/pkg/kine/tls"
@@ -74,7 +74,7 @@ func New(
 	watchAvailableStorageInterval time.Duration,
 	watchAvailableStorageMinBytes uint64,
 	lowAvailableStorageAction string,
-	connectionPoolConfig generic.ConnectionPoolConfig,
+	connectionPoolConfig sqlite.ConnectionPoolConfig,
 	watchQueryTimeout time.Duration,
 	watchProgressNotifyInterval time.Duration,
 

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCompaction(t *testing.T) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{ /*endpoint.SQLiteBackend,*/ endpoint.DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			t.Run("SmallDatabaseDeleteEntry", func(t *testing.T) {
 				g := NewWithT(t)

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCompaction(t *testing.T) {
-	for _, backendType := range []string{ /*SQLiteBackend,*/ DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			t.Run("SmallDatabaseDeleteEntry", func(t *testing.T) {
 				g := NewWithT(t)

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -5,13 +5,12 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	"github.com/canonical/k8s-dqlite/pkg/kine/sqllog"
 	. "github.com/onsi/gomega"
 )
 
 func TestCompaction(t *testing.T) {
-	for _, backendType := range []string{ /*endpoint.SQLiteBackend,*/ endpoint.DQLiteBackend} {
+	for _, backendType := range []string{ /*SQLiteBackend,*/ DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			t.Run("SmallDatabaseDeleteEntry", func(t *testing.T) {
 				g := NewWithT(t)
@@ -93,7 +92,7 @@ func TestCompaction(t *testing.T) {
 }
 
 func BenchmarkCompaction(b *testing.B) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			b.StopTimer()
 			ctx, cancel := context.WithCancel(context.Background())

--- a/test/create_test.go
+++ b/test/create_test.go
@@ -6,14 +6,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestCreate is unit testing for the create operation.
 func TestCreate(t *testing.T) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -37,7 +36,7 @@ func TestCreate(t *testing.T) {
 
 // BenchmarkCreate is a benchmark for the Create operation.
 func BenchmarkCreate(b *testing.B) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		for _, workers := range []int{1, 4, 16, 64, 128} {
 			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -7,14 +7,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestDelete is unit testing for the delete operation.
 func TestDelete(t *testing.T) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -66,7 +65,7 @@ func TestDelete(t *testing.T) {
 
 // BenchmarkDelete is a benchmark for the delete operation.
 func BenchmarkDelete(b *testing.B) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		for _, workers := range []int{1, 4, 16, 64, 128} {
 			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()

--- a/test/get_test.go
+++ b/test/get_test.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestGet is unit testing for the Get operation.
 func TestGet(t *testing.T) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -116,7 +115,7 @@ func TestGet(t *testing.T) {
 
 // BenchmarkGet is a benchmark for the Get operation.
 func BenchmarkGet(b *testing.B) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		b.Run(backendType, func(b *testing.B) {
 			b.StopTimer()
 			g := NewWithT(b)

--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -22,7 +21,7 @@ func TestLease(t *testing.T) {
 	const leaseValue = "testValue"
 	const ttlSeconds = 1
 
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestList is the unit test for List operation.
 func TestList(t *testing.T) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -191,7 +190,7 @@ func BenchmarkList(b *testing.B) {
 		}
 		return nil
 	}
-	backends := []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend}
+	backends := []string{SQLiteBackend, DQLiteBackend}
 	for _, backendType := range backends {
 		payloads := []struct {
 			name string

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -6,14 +6,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestUpdate is unit testing for the update operation.
 func TestUpdate(t *testing.T) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -106,7 +105,7 @@ func TestUpdate(t *testing.T) {
 
 // BenchmarkUpdate is a benchmark for the Update operation.
 func BenchmarkUpdate(b *testing.B) {
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		for _, workers := range []int{1, 4, 16, 64, 128} {
 			b.Run(fmt.Sprintf("%s/%d-workers", backendType, workers), func(b *testing.B) {
 				b.StopTimer()

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -84,7 +84,7 @@ func newKineServer(ctx context.Context, tb testing.TB, options *kineOptions) *ki
 	for _, param := range options.endpointParameters {
 		endpointConfig.Endpoint = fmt.Sprintf("%s&%s", endpointConfig.Endpoint, param)
 	}
-	config, backend, err := endpoint.ListenAndReturnBackend(ctx, *endpointConfig)
+	config, backend, err := endpoint.ListenAndReturnBackend(ctx, endpointConfig)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -141,9 +141,18 @@ func newKineServer(ctx context.Context, tb testing.TB, options *kineOptions) *ki
 }
 
 func startSqlite(ctx context.Context, tb testing.TB, dir string) (*sqlite.Driver, *sql.DB) {
-	dbPath := path.Join(dir, "data.db?_journal=WAL&_synchronous=FULL&_foreign_keys=1")
+	dbPath := path.Join(dir, "data.db")
 
-	db, err := sql.Open("sqlite3", dbPath)
+	dbUri := url.URL{
+		Path: dbPath,
+		RawQuery: url.Values{
+			"_journal":      []string{"WAL"},
+			"_synchronous":  []string{"FULL"},
+			"_foreign_keys": []string{"1"},
+		}.Encode(),
+	}
+
+	db, err := sql.Open("sqlite3", dbUri.String())
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -148,7 +148,7 @@ func startSqlite(ctx context.Context, tb testing.TB, dir string) (*sqlite.Driver
 		tb.Fatal(err)
 	}
 
-	driver, err := sqlite.NewDriver(ctx, &sqlite.DriverOptions{
+	driver, err := sqlite.NewDriver(ctx, &sqlite.DriverConfig{
 		DB: database.NewPrepared(db),
 	})
 	if err != nil {
@@ -182,7 +182,7 @@ func startDqlite(ctx context.Context, tb testing.TB, dir string, listener *instr
 		tb.Fatal(err)
 	}
 
-	driver, err := dqlite.NewDriver(ctx, &dqlite.DriverOptions{
+	driver, err := dqlite.NewDriver(ctx, &dqlite.DriverConfig{
 		DB: database.NewPrepared(db),
 	})
 	if err != nil {

--- a/test/watch_test.go
+++ b/test/watch_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/canonical/k8s-dqlite/pkg/kine/endpoint"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -25,7 +24,7 @@ func TestWatch(t *testing.T) {
 		idleTimeout = 100 * time.Millisecond
 	)
 
-	for _, backendType := range []string{endpoint.SQLiteBackend, endpoint.DQLiteBackend} {
+	for _, backendType := range []string{SQLiteBackend, DQLiteBackend} {
 		t.Run(backendType, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()


### PR DESCRIPTION
This PR removes the `generic` package and merges that with `sqlite`.

It also takes this opportunity to move many driver-unrelated stuff up in the instantiation chain, so that `sqlite` is now just a driver around a `*sql.DB` connection that is able to "talk" SQLite  sql dialect.

