### PR TITLE
Collect core dumps

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -124,3 +124,15 @@ jobs:
         with:
           name: ${{ env.artifact_name }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
+      - name: Upload base-code.snap
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: base
+          path: ${{ github.workspace }}/base-code.snap
+      - name: Upload head.snap
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: base
+          path: ${{ github.workspace }}/head.snap

--- a/hack/dynamic-dqlite.sh
+++ b/hack/dynamic-dqlite.sh
@@ -92,7 +92,7 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
     cd dqlite
     autoreconf -i > /dev/null
     ./configure --enable-build-raft \
-      CFLAGS="-I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -Werror=implicit-function-declaration" \
+      CFLAGS="-g -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -Werror=implicit-function-declaration" \
       LDFLAGS=" -L${BUILD_DIR}/libuv/.libs -L${BUILD_DIR}/lz4/lib -L${BUILD_DIR}/libnsl/src" \
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \

--- a/hack/dynamic-go-build.sh
+++ b/hack/dynamic-go-build.sh
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go build \
   -tags libsqlite3 \
-  -ldflags '-s -w -extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
+  -ldflags '-extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"

--- a/hack/static-dqlite.sh
+++ b/hack/static-dqlite.sh
@@ -123,7 +123,7 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
     cd dqlite
     autoreconf -i > /dev/null
     ./configure --disable-shared --enable-build-raft \
-      CFLAGS="${CFLAGS} -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -I${INSTALL_DIR}/musl/include -Werror=implicit-function-declaration" \
+      CFLAGS="-g ${CFLAGS} -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -I${INSTALL_DIR}/musl/include -Werror=implicit-function-declaration" \
       LDFLAGS="${LDFLAGS} -L${BUILD_DIR}/libuv/.libs -L${BUILD_DIR}/lz4/lib -L${BUILD_DIR}/libnsl/src" \
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \

--- a/hack/static-go-build.sh
+++ b/hack/static-go-build.sh
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go build \
   -tags libsqlite3 \
-  -ldflags '-s -w -linkmode "external" -extldflags "-static"' \
+  -ldflags '-linkmode "external" -extldflags "-static"' \
   "${@}"

--- a/test/performance/tests/conftest.py
+++ b/test/performance/tests/conftest.py
@@ -31,8 +31,15 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
     inspection_path = Path(config.INSPECTION_REPORTS_DIR)
     result = h.exec(
         instance_id,
-        ["/snap/k8s/current/k8s/scripts/inspect.sh", "--all-namespaces",
-         "--num-snap-log-entries", "1000000", "/inspection-report.tar.gz"],
+        [
+            "/snap/k8s/current/k8s/scripts/inspect.sh",
+            "--all-namespaces",
+            "--num-snap-log-entries",
+            "1000000",
+            "--core-dump-dir",
+            config.CORE_DUMP_DIR,
+            "/inspection-report.tar.gz",
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -160,6 +167,7 @@ def instances(
         instance = h.new_instance(network_type=network_type)
         instances.append(instance)
         if not no_setup:
+            util.setup_core_dumps(instance)
             util.setup_k8s_snap(instance, tmp_path, snap)
 
     if not disable_k8s_bootstrapping and not no_setup:

--- a/test/performance/tests/conftest.py
+++ b/test/performance/tests/conftest.py
@@ -31,7 +31,8 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
     inspection_path = Path(config.INSPECTION_REPORTS_DIR)
     result = h.exec(
         instance_id,
-        ["/snap/k8s/current/k8s/scripts/inspect.sh", "/inspection-report.tar.gz"],
+        ["/snap/k8s/current/k8s/scripts/inspect.sh", "--all-namespaces",
+         "--num-snap-log-entries", "1000000", "/inspection-report.tar.gz"],
         capture_output=True,
         text=True,
         check=False,

--- a/test/performance/tests/test_util/config.py
+++ b/test/performance/tests/test_util/config.py
@@ -24,6 +24,10 @@ INSPECTION_REPORTS_DIR = os.getenv("TEST_INSPECTION_REPORTS_DIR")
 # after the tests complete.
 SKIP_CLEANUP = (os.getenv("TEST_SKIP_CLEANUP") or "") == "1"
 
+# Note that when using containers, this will override the host configuration.
+CORE_DUMP_PATTERN = (os.getenv("TEST_CORE_DUMP_PATTERN")) or r"core-%e.%p.%h"
+CORE_DUMP_DIR = (os.getenv("TEST_CORE_DUMP_DIR")) or "/var/crash"
+
 # SNAP is the path to the snap under test.
 SNAP = os.getenv("TEST_SNAP") or ""
 

--- a/test/performance/tests/test_util/util.py
+++ b/test/performance/tests/test_util/util.py
@@ -4,6 +4,7 @@
 import ipaddress
 import json
 import logging
+import os
 import re
 import shlex
 import subprocess
@@ -144,6 +145,14 @@ def _as_int(value: Optional[str]) -> Optional[int]:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def setup_core_dumps(instance: harness.Instance):
+    core_pattern = os.path.join(config.CORE_DUMP_DIR, config.CORE_DUMP_PATTERN)
+    LOG.info("Configuring core dumps. Pattern: %s", core_pattern)
+    instance.exec(["echo", core_pattern, ">", "/proc/sys/kernel/core_pattern"])
+    instance.exec(["echo", "1", ">", "/proc/sys/fs/suid_dumpable"])
+    instance.exec(["snap", "set", "system", "system.coredump.enable=true"])
 
 
 def configure_dqlite_logging(instance: harness.Instance):


### PR DESCRIPTION
In order to debug crash dumps such as the dqlite ones that we're experiencing, we'll make the following changes:

* include debug symbols by default
* collect core dumps
* upload the snaps in case of e2e test failures so that we may analyse the core dumps

Depends on: https://github.com/canonical/k8s-snap/pull/1014

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
