### PR TITLE
Default and minimum snapshot parameters

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -245,11 +245,11 @@ func New(
 		if v := tuning.Snapshot; v != nil {
 			logrus.WithFields(logrus.Fields{"threshold": v.Threshold, "trailing": v.Trailing}).Print("Configure dqlite raft snapshot parameters")
 			if v.Trailing < v.Threshold {
-				return nil, fmt.Errorf("trailing snapshot threshold must be less than snapshot threshold")
+				return nil, fmt.Errorf("the snapshot's trailing parameter must be less than the threshold parameter")
 			}
 			// ensure that the threshold is at least 384 and trailing is at least 512 to avoid CPU utilization issues.
 			if v.Threshold < min_trailing || v.Trailing < min_trailing {
-				logrus.WithFields(logrus.Fields{"threshold": min_threshold, "trailing": min_trailing}).Print("Adjusting dqlite raft snapshot parameters")
+				logrus.WithFields(logrus.Fields{"threshold": min_threshold, "trailing": min_trailing}).Print("Using dqlite raft minimum snapshot parameters, as provided value(s) are too low")
 				v.Threshold = min_threshold
 				v.Trailing = min_trailing
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -258,13 +258,11 @@ func New(
 				logrus.WithFields(logrus.Fields{"adjustedTrailing": snapshotParameters.Trailing}).Warning("Trailing value is too low, setting to minimum value")
 			}
 			if v.Threshold == 0 {
-				snapshotParameters.Threshold = v.Trailing / 2
+				snapshotParameters.Threshold = v.Trailing * 3 / 4
 				logrus.WithFields(logrus.Fields{"adjustedThreshold": snapshotParameters.Threshold}).Warning("Threshold value is zero, setting to half of trailing value")
-
 			} else if v.Threshold < minThreshold {
 				snapshotParameters.Threshold = minThreshold
 				logrus.WithFields(logrus.Fields{"adjustedThreshold": snapshotParameters.Threshold}).Warning("Threshold value is too low, setting to minimum value")
-
 			}
 			if v.Threshold > v.Trailing {
 				snapshotParameters.Threshold = v.Trailing

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -254,7 +254,7 @@ func New(
 			if v.Trailing < minTrailing && v.Threshold > minThreshold {
 				snapshotParameters.Trailing = v.Threshold * scalingFactor
 				snapshotParameters.Threshold = v.Threshold
-			} else if v.Threshold < minThreshold && v.Trailing > minThreshold {
+			} else if v.Threshold < minThreshold && v.Trailing > minTrailing {
 				snapshotParameters.Threshold = v.Trailing * 1 / scalingFactor
 				snapshotParameters.Trailing = v.Trailing
 			} else if v.Trailing < minTrailing && v.Threshold < minThreshold {


### PR DESCRIPTION
## Default and minimum snapshot parameters

For context see issue: https://github.com/canonical/k8s-dqlite/issues/196

The currently used Dqlite snapshot parameters are set too high for small clusters.
This PR adjusts the default snapshot parameter's used.
It also implements some guardrails for setting the parameters via the tuning config.