### PR TITLE
perf test: fix snap artifact names

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -128,11 +128,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: base
+          name: base-code.snap
           path: ${{ github.workspace }}/base-code.snap
       - name: Upload head.snap
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: base
+          name: head.snap
           path: ${{ github.workspace }}/head.snap


### PR DESCRIPTION
By mistake, we're using the same name for both snap artifacts, which is why the snap upload fails.

This commit will update the artifact names to match the snap file names.

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
