### PR TITLE
donotmerge: reproduce kube-burner crashes (no trace msg, higher load)

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -77,10 +77,19 @@ jobs:
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
           TEST_METRICS_DIR: ${{ github.workspace }}/test/performance/results/head
           TEST_RUN_NAME: head
+          TEST_DQLITE_TRACE_LEVEL: 1
+          TEST_RAFT_TRACE_LEVEL: 1
+          TEST_K8S_DQLITE_DEBUG: 1
         run: |
           cd test/performance
           mkdir -p ./results/head
-          sg lxd -c 'tox -e performance'
+          set -ex
+          iteration=0
+          while [[ $iteration -lt 10 ]]; do
+            echo "iteration: $iteration"
+            sg lxd -c 'tox -e performance'
+            iteration=$(( $iteration + 1 ))
+          done
       - name: Run Performance test for base code snap
         env:
           TEST_SNAP: ${{ github.workspace }}/base-code.snap
@@ -89,16 +98,25 @@ jobs:
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
           TEST_METRICS_DIR: ${{ github.workspace }}/test/performance/results/base-code
           TEST_RUN_NAME: base-code
+          TEST_DQLITE_TRACE_LEVEL: 1
+          TEST_RAFT_TRACE_LEVEL: 1
+          TEST_K8S_DQLITE_DEBUG: 1
         run: |
           cd test/performance 
           mkdir -p ./results/base-code
-          sg lxd -c 'tox -e performance'
-      - name: Generate 3 node Graphs
-        if: always()
-        run: |
-          cd test/performance
-          sudo Rscript parse-performance-metrics.R -p ./results/head -o ./results/head -f *three-node.log
-          sudo Rscript parse-performance-metrics.R -p ./results/base-code -o ./results/base-code -f *three-node.log
+          set -ex
+          iteration=0
+          while [[ $iteration -lt 10 ]]; do
+            echo "iteration: $iteration"
+            sg lxd -c 'tox -e performance'
+            iteration=$(( $iteration + 1 ))
+          done
+      # - name: Generate 3 node Graphs
+      #   if: always()
+      #   run: |
+      #     cd test/performance
+      #     sudo Rscript parse-performance-metrics.R -p ./results/head -o ./results/head -f *three-node.log
+      #     sudo Rscript parse-performance-metrics.R -p ./results/base-code -o ./results/base-code -f *three-node.log
       - name: Generate single node Graphs
         if: always()
         run: |

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -87,7 +87,7 @@ jobs:
           iteration=0
           while [[ $iteration -lt 5 ]]; do
             echo "iteration: $iteration"
-            sg lxd -c 'tox -e performance'
+            sg lxd -c 'tox -e performance -- -k test_single_node_load'
             iteration=$(( $iteration + 1 ))
           done
       - name: Run Performance test for base code snap
@@ -108,7 +108,7 @@ jobs:
           iteration=0
           while [[ $iteration -lt 5 ]]; do
             echo "iteration: $iteration"
-            sg lxd -c 'tox -e performance'
+            sg lxd -c 'tox -e performance -- -k test_single_node_load'
             iteration=$(( $iteration + 1 ))
           done
       # - name: Generate 3 node Graphs

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -85,7 +85,7 @@ jobs:
           mkdir -p ./results/head
           set -ex
           iteration=0
-          while [[ $iteration -lt 10 ]]; do
+          while [[ $iteration -lt 5 ]]; do
             echo "iteration: $iteration"
             sg lxd -c 'tox -e performance'
             iteration=$(( $iteration + 1 ))
@@ -106,7 +106,7 @@ jobs:
           mkdir -p ./results/base-code
           set -ex
           iteration=0
-          while [[ $iteration -lt 10 ]]; do
+          while [[ $iteration -lt 5 ]]; do
             echo "iteration: $iteration"
             sg lxd -c 'tox -e performance'
             iteration=$(( $iteration + 1 ))

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -85,7 +85,7 @@ jobs:
           mkdir -p ./results/head
           set -ex
           iteration=0
-          while [[ $iteration -lt 5 ]]; do
+          while [[ $iteration -lt 2 ]]; do
             echo "iteration: $iteration"
             sg lxd -c 'tox -e performance -- -k test_single_node_load'
             iteration=$(( $iteration + 1 ))
@@ -102,11 +102,11 @@ jobs:
           # TEST_RAFT_TRACE_LEVEL: 1
           # TEST_K8S_DQLITE_DEBUG: 1
         run: |
-          cd test/performance 
+          cd test/performance
           mkdir -p ./results/base-code
           set -ex
           iteration=0
-          while [[ $iteration -lt 5 ]]; do
+          while [[ $iteration -lt 2 ]]; do
             echo "iteration: $iteration"
             sg lxd -c 'tox -e performance -- -k test_single_node_load'
             iteration=$(( $iteration + 1 ))

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -77,9 +77,9 @@ jobs:
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
           TEST_METRICS_DIR: ${{ github.workspace }}/test/performance/results/head
           TEST_RUN_NAME: head
-          TEST_DQLITE_TRACE_LEVEL: 1
-          TEST_RAFT_TRACE_LEVEL: 1
-          TEST_K8S_DQLITE_DEBUG: 1
+          # TEST_DQLITE_TRACE_LEVEL: 1
+          # TEST_RAFT_TRACE_LEVEL: 1
+          # TEST_K8S_DQLITE_DEBUG: 1
         run: |
           cd test/performance
           mkdir -p ./results/head
@@ -98,9 +98,9 @@ jobs:
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
           TEST_METRICS_DIR: ${{ github.workspace }}/test/performance/results/base-code
           TEST_RUN_NAME: base-code
-          TEST_DQLITE_TRACE_LEVEL: 1
-          TEST_RAFT_TRACE_LEVEL: 1
-          TEST_K8S_DQLITE_DEBUG: 1
+          # TEST_DQLITE_TRACE_LEVEL: 1
+          # TEST_RAFT_TRACE_LEVEL: 1
+          # TEST_K8S_DQLITE_DEBUG: 1
         run: |
           cd test/performance 
           mkdir -p ./results/base-code

--- a/test/performance/templates/api-intensive.yaml
+++ b/test/performance/templates/api-intensive.yaml
@@ -4,9 +4,9 @@ global:
 
 jobs:
   - name: api-intensive
-    jobIterations: 1000
-    qps: 5000
-    burst: 5000
+    jobIterations: 500
+    qps: 2500
+    burst: 2500
     namespacedIterations: true
     namespace: api-intensive
     podWait: false
@@ -19,8 +19,8 @@ jobs:
       - objectTemplate: secret.yaml
         replicas: 10
   - name: remove-configmaps-secrets
-    qps: 1000
-    burst: 1000
+    qps: 500
+    burst: 500
     jobType: delete
     objects:
       - kind: ConfigMap

--- a/test/performance/templates/api-intensive.yaml
+++ b/test/performance/templates/api-intensive.yaml
@@ -4,9 +4,9 @@ global:
 
 jobs:
   - name: api-intensive
-    jobIterations: 100
-    qps: 500
-    burst: 500
+    jobIterations: 1000
+    qps: 5000
+    burst: 5000
     namespacedIterations: true
     namespace: api-intensive
     podWait: false
@@ -19,8 +19,8 @@ jobs:
       - objectTemplate: secret.yaml
         replicas: 10
   - name: remove-configmaps-secrets
-    qps: 100
-    burst: 100
+    qps: 1000
+    burst: 1000
     jobType: delete
     objects:
       - kind: ConfigMap

--- a/test/performance/tests/test_multi_node.py
+++ b/test/performance/tests/test_multi_node.py
@@ -9,6 +9,7 @@ from test_util import harness, metrics, util
 
 @pytest.mark.node_count(3)
 def test_three_node_load(instances: List[harness.Instance]):
+    pytest.xfail("donotmerge: disabled")
     cluster_node = instances[0]
     joining_node = instances[1]
     joining_node_2 = instances[2]

--- a/test/performance/tests/test_single_node.py
+++ b/test/performance/tests/test_single_node.py
@@ -9,7 +9,8 @@ def test_single_node_load(session_instance: harness.Instance):
     metrics.configure_kube_burner(session_instance)
     process_dict = metrics.collect_metrics([session_instance])
     try:
-        metrics.run_kube_burner(session_instance)
+        for iteration in range(10):
+            metrics.run_kube_burner(session_instance)
     finally:
         # Collect the metrics even if kube-burner fails.
         metrics.stop_metrics([session_instance], process_dict)

--- a/test/performance/tests/test_single_node.py
+++ b/test/performance/tests/test_single_node.py
@@ -1,17 +1,31 @@
 #
 # Copyright 2025 Canonical, Ltd.
 #
+import logging
+
 from test_util import harness, metrics
+
+LOG = logging.getLogger(__name__)
 
 
 def test_single_node_load(session_instance: harness.Instance):
     """Test the performance of a single node cluster with all features enabled."""
     metrics.configure_kube_burner(session_instance)
     process_dict = metrics.collect_metrics([session_instance])
-    try:
-        for iteration in range(10):
+
+    raised_exc = None
+    for iteration in range(10):
+        try:
             metrics.run_kube_burner(session_instance)
-    finally:
-        # Collect the metrics even if kube-burner fails.
-        metrics.stop_metrics([session_instance], process_dict)
-        metrics.pull_metrics([session_instance], "single-node")
+        except Exception as ex:
+            LOG.exception("kube-burner failed, starting new iteration.")
+            # We'll start another iteration even if the test failed to see
+            # if it was a transient failure or if Dqlite was compromised.
+            raised_exc = ex
+
+    # Collect the metrics even if kube-burner fails.
+    metrics.stop_metrics([session_instance], process_dict)
+    metrics.pull_metrics([session_instance], "single-node")
+
+    if raised_exc:
+        raise raised_exc


### PR DESCRIPTION
* run the perf tests in a loop (10 * 10 iterations)
* similar to https://github.com/canonical/k8s-dqlite/pull/224, but without debug logging and 10 times the workload (may increase the chances of hitting the crash)

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
