### PR TITLE
CI: Add matrix (os, arch) to the integration test

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
         arch: ["arm64", "amd64"]
+      fail-fast: false
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -16,7 +16,9 @@ jobs:
   build:
     name: K8s-snap Integration Test
     runs-on: self-hosted-linux-amd64-jammy-large
-
+    strategy:
+      matrix:
+        os: [ubuntu:20.04, ubuntu:22.04, ubuntu:24.04]
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
@@ -52,7 +54,7 @@ jobs:
         env:
           TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap
           TEST_SUBSTRATE: lxd
-          TEST_LXD_IMAGE: ubuntu:22.04
+          TEST_LXD_IMAGE: ${{ matrix.os}}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
           git clone https://github.com/canonical/k8s-snap.git      

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -14,11 +14,12 @@ concurrency:
 
 jobs:
   build:
-    name: K8s-snap Integration Test on ${{ matrix.os }}
-    runs-on: self-hosted-linux-amd64-jammy-large
+    name: K8s-snap Integration Test on ${{ matrix.os }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
     strategy:
       matrix:
         os: [ubuntu:20.04, ubuntu:22.04, ubuntu:24.04]
+        arch: [arm64, amd64]
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
     strategy:
       matrix:
-        os: [ubuntu:20.04, ubuntu:22.04, ubuntu:24.04]
-        arch: [arm64, amd64]
+        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+        arch: ["arm64", "amd64"]
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    name: K8s-snap Integration Test
+    name: K8s-snap Integration Test on ${{ matrix.os }}
     runs-on: self-hosted-linux-amd64-jammy-large
     strategy:
       matrix:


### PR DESCRIPTION
## Description 
Increase testing on different OS+Arch for the k8s snap e2e test. We hope to catch more changes that cause flaky tests.
This PR also updates top-level permissions for our gh workflows.
