### PR TITLE
bug: Fix memory leak watch context cancel

### DIFF
--- a/pkg/kine/sqllog/sqllog.go
+++ b/pkg/kine/sqllog/sqllog.go
@@ -518,20 +518,8 @@ func (s *SQLLog) poll(ctx context.Context, result chan []*server.Event, pollStar
 			}
 		}
 		waitForMore = true
-		watchCtx, cancel := context.WithTimeout(ctx, s.config.WatchQueryTimeout)
-		defer cancel()
-
-		rows, err := s.config.Driver.After(watchCtx, last, pollBatchSize)
+		events, err := s.getLatestEvents(ctx, last)
 		if err != nil {
-			if !errors.Is(err, context.DeadlineExceeded) {
-				logrus.Errorf("fail to list latest changes: %v", err)
-			}
-			continue
-		}
-
-		events, err := ScanAll(rows, scanEvent)
-		if err != nil {
-			logrus.Errorf("fail to convert rows changes: %v", err)
 			continue
 		}
 
@@ -597,6 +585,26 @@ func (s *SQLLog) poll(ctx context.Context, result chan []*server.Event, pollStar
 			}
 		}
 	}
+}
+
+func (s *SQLLog) getLatestEvents(ctx context.Context, last int64) ([]*server.Event, error) {
+	watchCtx, cancel := context.WithTimeout(ctx, s.config.WatchQueryTimeout)
+	defer cancel()
+
+	rows, err := s.config.Driver.After(watchCtx, last, pollBatchSize)
+	if err != nil {
+		if !errors.Is(err, context.DeadlineExceeded) {
+			logrus.Errorf("fail to list latest changes: %v", err)
+		}
+		return nil, err
+	}
+
+	events, err := ScanAll(rows, scanEvent)
+	if err != nil {
+		logrus.Errorf("fail to convert rows changes: %v", err)
+		return nil, err
+	}
+	return events, nil
 }
 
 func canSkipRevision(rev, skip int64, skipTime time.Time) bool {


### PR DESCRIPTION
## Description
We've detected a leak in the watch poll loop.
The watch context never gets cancelled as it is part of the long running loop:
![image](https://github.com/user-attachments/assets/224549be-f447-4190-8aa4-61d1425b6ece)
