### PR TITLE
back-port: [v1.1] Fix memory leak watch context cancel (#240)

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Dqlite
         run: |
           sudo add-apt-repository -y ppa:dqlite/dev 
-          sudo apt install libdqlite-dev
+          sudo apt install libdqlite-dev libraft-dev
 
       - name: Run benchmarks
         run: |


### PR DESCRIPTION
## Description
Back-port of https://github.com/canonical/k8s-dqlite/pull/240