### PR TITLE
Improve retry logic

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -61,8 +61,9 @@ jobs:
       - name: Create snap with k8s-dqlite base-code
         run: |
           set -o pipefail
-          git fetch origin $BASE_BRANCH
-          git reset --hard $BASE_SHA
+          # dbg: Log retries
+          git fetch origin lpetrut/log-retries
+          git reset --hard origin/lpetrut/log-retries
           make static
           sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
           sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
@@ -91,7 +92,7 @@ jobs:
           TEST_RUN_NAME: base-code
           TEST_KUBE_BURNER_ITERATIONS: 15
         run: |
-          cd test/performance 
+          cd test/performance
           sg lxd -c 'tox -e performance -- -k test_single_node'
       - name: Generate aggregated Graphs
         if: always()

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -80,7 +80,7 @@ jobs:
           TEST_KUBE_BURNER_ITERATIONS: 15
         run: |
           cd test/performance
-          sg lxd -c 'tox -e performance'
+          sg lxd -c 'tox -e performance -- -k test_single_node'
       - name: Run Performance test for base code snap
         env:
           TEST_SNAP: ${{ github.workspace }}/base-code.snap
@@ -91,8 +91,8 @@ jobs:
           TEST_RUN_NAME: base-code
           TEST_KUBE_BURNER_ITERATIONS: 15
         run: |
-          cd test/performance
-          sg lxd -c 'tox -e performance'
+          cd test/performance 
+          sg lxd -c 'tox -e performance -- -k test_single_node'
       - name: Generate aggregated Graphs
         if: always()
         run: |

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 )
 
 require (
+	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 )
 
 require (
-	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/pkg/k8s_dqlite/drivers/sqlite/driver.go
+++ b/pkg/k8s_dqlite/drivers/sqlite/driver.go
@@ -395,7 +395,7 @@ func (d *Driver) query(ctx context.Context, txName, query string, args ...interf
 		}
 		recordOpResult(txName, err, start)
 	}()
-	wait := strategy.Backoff(backoff.Linear(100 + time.Millisecond))
+	wait := strategy.Backoff(backoff.Linear(10 * time.Millisecond))
 	for ; retryCount < maxRetries; retryCount++ {
 		if retryCount == 0 {
 			logrus.Tracef("QUERY (try: %d) %v : %s", retryCount, args, Stripped(query))
@@ -435,7 +435,7 @@ func (d *Driver) execute(ctx context.Context, txName, query string, args ...inte
 		}
 		recordOpResult(txName, err, start)
 	}()
-	wait := strategy.Backoff(backoff.Linear(100 + time.Millisecond))
+	wait := strategy.Backoff(backoff.Linear(10 * time.Millisecond))
 	for ; retryCount < maxRetries; retryCount++ {
 		if retryCount > 2 {
 			logrus.Debugf("EXEC (try: %d) %v : %s", retryCount, args, Stripped(query))
@@ -581,7 +581,7 @@ func (d *Driver) Compact(ctx context.Context, revision int64) (err error) {
 		revision = currentRevision
 	}
 
-	wait := strategy.Backoff(backoff.Linear(100 + time.Millisecond))
+	wait := strategy.Backoff(backoff.Linear(10 * time.Millisecond))
 	for retryCount := 0; retryCount < maxRetries; retryCount++ {
 		err = d.tryCompact(ctx, compactStart, revision)
 		if err == nil || !d.config.Retry(err) {


### PR DESCRIPTION
k8s-dqlite currently performs 500 retries without a backoff interval. This poses two problems:

* there may not be enough time for the db or db connection to recover
* we're putting a huge load on the db

This change will:
* use a retry timeout (5s) rather than a maximum number of retries (500)
* sleep between retries using a linear backoff (increased by 10ms per iteration with a 100ms limit)

Based on the retries performed by Kine:

https://github.com/k3s-io/kine/blob/99ca124a4d3cc01c30c13b9d2026e7eddd5e37bb/pkg/drivers/generic/generic.go#L277-L287

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
