### PR TITLE
Use list ranges instead of prefixes

### DIFF
--- a/pkg/kine/drivers/sqlite/driver.go
+++ b/pkg/kine/drivers/sqlite/driver.go
@@ -489,12 +489,10 @@ func (d *Driver) Create(ctx context.Context, key, value []byte, ttl int64) (rev 
 		span.SetAttributes(attribute.Int64("revision", rev))
 		span.End()
 	}()
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(key)),
-			attribute.Int64("ttl", ttl),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(key)),
+		attribute.Int64("ttl", ttl),
+	)
 	createCnt.Add(ctx, 1)
 
 	result, err := d.execute(ctx, "create_sql", createSQL, key, ttl, value, key)
@@ -542,9 +540,7 @@ func (d *Driver) Delete(ctx context.Context, key []byte, revision int64) (rev in
 		span.SetAttributes(attribute.Bool("deleted", deleted))
 		span.End()
 	}()
-	if span.IsRecording() {
-		span.SetAttributes(attribute.String("key", string(key)))
-	}
+	span.SetAttributes(attribute.String("key", string(key)))
 
 	result, err := d.execute(ctx, "delete_sql", deleteSQL, key, revision)
 	if err != nil {

--- a/pkg/kine/drivers/sqlite/driver.go
+++ b/pkg/kine/drivers/sqlite/driver.go
@@ -79,6 +79,9 @@ func init() {
 	}
 }
 
+// Certain parameters such as keys or range limits are represented as byte slices,
+// for which reason we need casts: CAST(? AS TEXT). Note that this should be a
+// no-op for sqlite.
 var (
 	revSQL = `
 		SELECT MAX(rkv.id) AS id

--- a/pkg/kine/drivers/sqlite/driver.go
+++ b/pkg/kine/drivers/sqlite/driver.go
@@ -466,11 +466,11 @@ func (d *Driver) execute(ctx context.Context, txName, query string, args ...inte
 	return result, err
 }
 
-func (d *Driver) Count(ctx context.Context, key, end []byte, revision int64) (int64, error) {
-	if len(end) == 0 {
-		end = append(key, 1)
+func (d *Driver) Count(ctx context.Context, key, rangeEnd []byte, revision int64) (int64, error) {
+	if len(rangeEnd) == 0 {
+		rangeEnd = append(key, 1)
 	}
-	rows, err := d.query(ctx, "count_revision", countRevisionSQL, key, end, revision)
+	rows, err := d.query(ctx, "count_revision", countRevisionSQL, key, rangeEnd, revision)
 	if err != nil {
 		return 0, err
 	}
@@ -703,16 +703,16 @@ func (d *Driver) DeleteRevision(ctx context.Context, revision int64) error {
 	return err
 }
 
-func (d *Driver) List(ctx context.Context, key, end []byte, limit, revision int64) (*sql.Rows, error) {
-	if len(end) == 0 {
-		end = append(key, 1)
+func (d *Driver) List(ctx context.Context, key, rangeEnd []byte, limit, revision int64) (*sql.Rows, error) {
+	if len(rangeEnd) == 0 {
+		rangeEnd = append(key, 1)
 	}
 	sql := listSQL
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT ?", sql)
-		return d.query(ctx, "list_revision_start_sql_limit", sql, key, end, revision, limit)
+		return d.query(ctx, "list_revision_start_sql_limit", sql, key, rangeEnd, revision, limit)
 	}
-	return d.query(ctx, "list_revision_start_sql", sql, key, end, revision)
+	return d.query(ctx, "list_revision_start_sql", sql, key, rangeEnd, revision)
 }
 
 func (d *Driver) ListTTL(ctx context.Context, revision int64) (*sql.Rows, error) {

--- a/pkg/kine/drivers/sqlite/driver.go
+++ b/pkg/kine/drivers/sqlite/driver.go
@@ -468,7 +468,7 @@ func (d *Driver) execute(ctx context.Context, txName, query string, args ...inte
 
 func (d *Driver) Count(ctx context.Context, key, rangeEnd []byte, revision int64) (int64, error) {
 	if len(rangeEnd) == 0 {
-		rangeEnd = append(key, 1)
+		rangeEnd = append(key, 0)
 	}
 	rows, err := d.query(ctx, "count_revision", countRevisionSQL, key, rangeEnd, revision)
 	if err != nil {
@@ -705,7 +705,7 @@ func (d *Driver) DeleteRevision(ctx context.Context, revision int64) error {
 
 func (d *Driver) List(ctx context.Context, key, rangeEnd []byte, limit, revision int64) (*sql.Rows, error) {
 	if len(rangeEnd) == 0 {
-		rangeEnd = append(key, 1)
+		rangeEnd = append(key, 0)
 	}
 	sql := listSQL
 	if limit > 0 {

--- a/pkg/kine/server/create.go
+++ b/pkg/kine/server/create.go
@@ -29,12 +29,10 @@ func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest
 		span.RecordError(err)
 		span.End()
 	}()
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(put.Key)),
-			attribute.Int64("lease", put.Lease),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(put.Key)),
+		attribute.Int64("lease", put.Lease),
+	)
 
 	if put.IgnoreLease {
 		return nil, unsupported("ignoreLease")

--- a/pkg/kine/server/create.go
+++ b/pkg/kine/server/create.go
@@ -29,10 +29,12 @@ func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest
 		span.RecordError(err)
 		span.End()
 	}()
-	span.SetAttributes(
-		attribute.String("key", string(put.Key)),
-		attribute.Int64("lease", put.Lease),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("key", string(put.Key)),
+			attribute.Int64("lease", put.Lease),
+		)
+	}
 
 	if put.IgnoreLease {
 		return nil, unsupported("ignoreLease")
@@ -42,7 +44,7 @@ func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest
 		return nil, unsupported("prevKv")
 	}
 
-	rev, created, err := l.backend.Create(ctx, string(put.Key), put.Value, put.Lease)
+	rev, created, err := l.backend.Create(ctx, put.Key, put.Value, put.Lease)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -56,7 +56,7 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 			},
 		}
 	} else {
-		rev, kv, err := l.backend.List(ctx, key, "", 1, rev)
+		rev, kv, err := l.backend.List(ctx, []byte(key), []byte(""), 1, rev)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -28,12 +28,10 @@ func (l *LimitedServer) delete(ctx context.Context, key []byte, revision int64) 
 		span.RecordError(err)
 		span.End()
 	}()
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(key)),
-			attribute.Int64("revision", revision),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(key)),
+		attribute.Int64("revision", revision),
+	)
 
 	rev, deleted, err := l.backend.Delete(ctx, key, revision)
 	if err != nil {

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -18,7 +18,7 @@ func isDelete(txn *etcdserverpb.TxnRequest) (int64, []byte, bool) {
 		txn.Success[0].GetRequestDeleteRange() != nil {
 		return txn.Compare[0].GetModRevision(), txn.Success[0].GetRequestDeleteRange().Key, true
 	}
-	return 0, []byte{}, false
+	return 0, nil, false
 }
 
 func (l *LimitedServer) delete(ctx context.Context, key []byte, revision int64) (_ *etcdserverpb.TxnResponse, err error) {
@@ -56,7 +56,7 @@ func (l *LimitedServer) delete(ctx context.Context, key []byte, revision int64) 
 			},
 		}
 	} else {
-		rev, kv, err := l.backend.List(ctx, key, []byte{}, 1, rev)
+		rev, kv, err := l.backend.List(ctx, key, nil, 1, rev)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func isDelete(txn *etcdserverpb.TxnRequest) (int64,  []byte, bool) {
+func isDelete(txn *etcdserverpb.TxnRequest) (int64, []byte, bool) {
 	if len(txn.Compare) == 1 &&
 		txn.Compare[0].Target == etcdserverpb.Compare_MOD &&
 		txn.Compare[0].Result == etcdserverpb.Compare_EQUAL &&

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func isDelete(txn *etcdserverpb.TxnRequest) (int64, string, bool) {
+func isDelete(txn *etcdserverpb.TxnRequest) (int64,  []byte, bool) {
 	if len(txn.Compare) == 1 &&
 		txn.Compare[0].Target == etcdserverpb.Compare_MOD &&
 		txn.Compare[0].Result == etcdserverpb.Compare_EQUAL &&
@@ -16,12 +16,12 @@ func isDelete(txn *etcdserverpb.TxnRequest) (int64, string, bool) {
 		txn.Failure[0].GetRequestRange() != nil &&
 		len(txn.Success) == 1 &&
 		txn.Success[0].GetRequestDeleteRange() != nil {
-		return txn.Compare[0].GetModRevision(), string(txn.Success[0].GetRequestDeleteRange().Key), true
+		return txn.Compare[0].GetModRevision(), txn.Success[0].GetRequestDeleteRange().Key, true
 	}
-	return 0, "", false
+	return 0, []byte{}, false
 }
 
-func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) (_ *etcdserverpb.TxnResponse, err error) {
+func (l *LimitedServer) delete(ctx context.Context, key []byte, revision int64) (_ *etcdserverpb.TxnResponse, err error) {
 	deleteCnt.Add(ctx, 1)
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.delete", otelName))
 	defer func() {
@@ -29,11 +29,11 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 		span.End()
 	}()
 	span.SetAttributes(
-		attribute.String("key", key),
+		attribute.String("key", string(key)),
 		attribute.Int64("revision", revision),
 	)
 
-	rev, deleted, err := l.backend.Delete(ctx, key, revision)
+	rev, deleted, err := l.backend.Delete(ctx, string(key), revision)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 			},
 		}
 	} else {
-		rev, kv, err := l.backend.List(ctx, []byte(key), []byte(""), 1, rev)
+		rev, kv, err := l.backend.List(ctx, key, []byte{}, 1, rev)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kine/server/delete.go
+++ b/pkg/kine/server/delete.go
@@ -28,12 +28,14 @@ func (l *LimitedServer) delete(ctx context.Context, key []byte, revision int64) 
 		span.RecordError(err)
 		span.End()
 	}()
-	span.SetAttributes(
-		attribute.String("key", string(key)),
-		attribute.Int64("revision", revision),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("key", string(key)),
+			attribute.Int64("revision", revision),
+		)
+	}
 
-	rev, deleted, err := l.backend.Delete(ctx, string(key), revision)
+	rev, deleted, err := l.backend.Delete(ctx, key, revision)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kine/server/get.go
+++ b/pkg/kine/server/get.go
@@ -25,7 +25,7 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		)
 	}
 
-	rev, kv, err := l.backend.List(ctx, r.Key, []byte{}, 1, r.Revision)
+	rev, kv, err := l.backend.List(ctx, r.Key, nil, 1, r.Revision)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kine/server/get.go
+++ b/pkg/kine/server/get.go
@@ -17,13 +17,11 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		span.End()
 	}()
 
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(r.Key)),
-			attribute.Int64("limit", r.Limit),
-			attribute.Int64("revision", r.Revision),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(r.Key)),
+		attribute.Int64("limit", r.Limit),
+		attribute.Int64("revision", r.Revision),
+	)
 
 	rev, kv, err := l.backend.List(ctx, r.Key, nil, 1, r.Revision)
 	if err != nil {

--- a/pkg/kine/server/get.go
+++ b/pkg/kine/server/get.go
@@ -17,11 +17,13 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		span.End()
 	}()
 
-	span.SetAttributes(
-		attribute.String("key", string(r.Key)),
-		attribute.Int64("limit", r.Limit),
-		attribute.Int64("revision", r.Revision),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("key", string(r.Key)),
+			attribute.Int64("limit", r.Limit),
+			attribute.Int64("revision", r.Revision),
+		)
+	}
 
 	rev, kv, err := l.backend.List(ctx, r.Key, []byte{}, 1, r.Revision)
 	if err != nil {

--- a/pkg/kine/server/get.go
+++ b/pkg/kine/server/get.go
@@ -23,7 +23,7 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		attribute.Int64("revision", r.Revision),
 	)
 
-	rev, kv, err := l.backend.List(ctx, string(r.Key), "", 1, r.Revision)
+	rev, kv, err := l.backend.List(ctx, r.Key, []byte{}, 1, r.Revision)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kine/server/list.go
+++ b/pkg/kine/server/list.go
@@ -19,11 +19,13 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 	}()
 
 	revision := r.Revision
-	span.SetAttributes(
-		attribute.String("key", string(r.Key)),
-		attribute.String("rangeEnd", string(r.RangeEnd)),
-		attribute.Int64("revision", r.Revision),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("key", string(r.Key)),
+			attribute.String("rangeEnd", string(r.RangeEnd)),
+			attribute.Int64("revision", r.Revision),
+		)
+	}
 	if len(r.RangeEnd) == 0 {
 		return nil, fmt.Errorf("invalid range end length of 0")
 	}

--- a/pkg/kine/server/list.go
+++ b/pkg/kine/server/list.go
@@ -19,13 +19,11 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 	}()
 
 	revision := r.Revision
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(r.Key)),
-			attribute.String("rangeEnd", string(r.RangeEnd)),
-			attribute.Int64("revision", r.Revision),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(r.Key)),
+		attribute.String("rangeEnd", string(r.RangeEnd)),
+		attribute.Int64("revision", r.Revision),
+	)
 	if len(r.RangeEnd) == 0 {
 		return nil, fmt.Errorf("invalid range end length of 0")
 	}

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -14,12 +14,12 @@ var (
 type Backend interface {
 	Start(ctx context.Context) error
 	Stop() error
-	Create(ctx context.Context, key string, value []byte, lease int64) (int64, bool, error)
-	Delete(ctx context.Context, key string, revision int64) (int64, bool, error)
+	Create(ctx context.Context, key, value []byte, lease int64) (int64, bool, error)
+	Delete(ctx context.Context, key []byte, revision int64) (int64, bool, error)
 	List(ctx context.Context, key, end []byte, limit, revision int64) (int64, []*KeyValue, error)
 	Count(ctx context.Context, key, end []byte, revision int64) (int64, int64, error)
-	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, bool, error)
-	Watch(ctx context.Context, key string, revision int64) (<-chan []*Event, error)
+	Update(ctx context.Context, key, value []byte, revision, lease int64) (int64, bool, error)
+	Watch(ctx context.Context, key []byte, revision int64) (<-chan []*Event, error)
 	DbSize(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	GetCompactRevision(ctx context.Context) (int64, int64, error)

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -16,10 +16,10 @@ type Backend interface {
 	Stop() error
 	Create(ctx context.Context, key, value []byte, lease int64) (int64, bool, error)
 	Delete(ctx context.Context, key []byte, revision int64) (int64, bool, error)
-	List(ctx context.Context, key, end []byte, limit, revision int64) (int64, []*KeyValue, error)
-	Count(ctx context.Context, key, end []byte, revision int64) (int64, int64, error)
+	List(ctx context.Context, key, rangeEnd []byte, limit, revision int64) (int64, []*KeyValue, error)
+	Count(ctx context.Context, key, rangeEnd []byte, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key, value []byte, revision, lease int64) (int64, bool, error)
-	Watch(ctx context.Context, key []byte, revision int64) (<-chan []*Event, error)
+	Watch(ctx context.Context, key, rangeEnd []byte, revision int64) (<-chan []*Event, error)
 	DbSize(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	GetCompactRevision(ctx context.Context) (int64, int64, error)

--- a/pkg/kine/server/types.go
+++ b/pkg/kine/server/types.go
@@ -16,8 +16,8 @@ type Backend interface {
 	Stop() error
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, bool, error)
 	Delete(ctx context.Context, key string, revision int64) (int64, bool, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
-	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
+	List(ctx context.Context, key, end []byte, limit, revision int64) (int64, []*KeyValue, error)
+	Count(ctx context.Context, key, end []byte, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, bool, error)
 	Watch(ctx context.Context, key string, revision int64) (<-chan []*Event, error)
 	DbSize(ctx context.Context) (int64, error)

--- a/pkg/kine/server/update.go
+++ b/pkg/kine/server/update.go
@@ -22,7 +22,7 @@ func isUpdate(txn *etcdserverpb.TxnRequest) (int64, []byte, []byte, int64, bool)
 			txn.Success[0].GetRequestPut().Lease,
 			true
 	}
-	return 0, []byte{}, nil, 0, false
+	return 0, nil, nil, 0, false
 }
 
 func (l *LimitedServer) update(ctx context.Context, rev int64, key, value []byte, lease int64) (_ *etcdserverpb.TxnResponse, err error) {
@@ -66,7 +66,7 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key, value []byte
 			},
 		}
 	} else {
-		rev, kv, err := l.backend.List(ctx, key, []byte{}, 1, rev)
+		rev, kv, err := l.backend.List(ctx, key, nil, 1, rev)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kine/server/update.go
+++ b/pkg/kine/server/update.go
@@ -33,17 +33,19 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key, value []byte
 		span.RecordError(err)
 		span.End()
 	}()
-	span.SetAttributes(
-		attribute.String("key", string(key)),
-		attribute.Int64("lease", lease),
-		attribute.Int64("revision", rev),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("key", string(key)),
+			attribute.Int64("lease", lease),
+			attribute.Int64("revision", rev),
+		)
+	}
 
 	var succeeded bool
 	if rev == 0 {
-		rev, succeeded, err = l.backend.Create(ctx, string(key), value, lease)
+		rev, succeeded, err = l.backend.Create(ctx, key, value, lease)
 	} else {
-		rev, succeeded, err = l.backend.Update(ctx, string(key), value, rev, lease)
+		rev, succeeded, err = l.backend.Update(ctx, key, value, rev, lease)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/kine/server/update.go
+++ b/pkg/kine/server/update.go
@@ -33,13 +33,11 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key, value []byte
 		span.RecordError(err)
 		span.End()
 	}()
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(key)),
-			attribute.Int64("lease", lease),
-			attribute.Int64("revision", rev),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(key)),
+		attribute.Int64("lease", lease),
+		attribute.Int64("revision", rev),
+	)
 
 	var succeeded bool
 	if rev == 0 {

--- a/pkg/kine/server/update.go
+++ b/pkg/kine/server/update.go
@@ -66,7 +66,7 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 			},
 		}
 	} else {
-		rev, kv, err := l.backend.List(ctx, key, "", 1, rev)
+		rev, kv, err := l.backend.List(ctx, []byte(key), []byte{}, 1, rev)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kine/server/watch.go
+++ b/pkg/kine/server/watch.go
@@ -115,7 +115,7 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 			return
 		}
 
-		watchCh, err := w.backend.Watch(ctx, r.Key, startRevision)
+		watchCh, err := w.backend.Watch(ctx, r.Key, r.RangeEnd, startRevision)
 		if err != nil {
 			logrus.Errorf("Failed to start watch: %v", err)
 			w.Cancel(id, err)

--- a/pkg/kine/server/watch.go
+++ b/pkg/kine/server/watch.go
@@ -115,7 +115,7 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 			return
 		}
 
-		watchCh, err := w.backend.Watch(ctx, key, startRevision)
+		watchCh, err := w.backend.Watch(ctx, r.Key, startRevision)
 		if err != nil {
 			logrus.Errorf("Failed to start watch: %v", err)
 			w.Cancel(id, err)

--- a/pkg/kine/sqllog/sqllog.go
+++ b/pkg/kine/sqllog/sqllog.go
@@ -245,13 +245,11 @@ func (s *SQLLog) After(ctx context.Context, key, rangeEnd []byte, revision, limi
 		span.RecordError(err)
 		span.End()
 	}()
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(key)),
-			attribute.Int64("revision", revision),
-			attribute.Int64("limit", limit),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(key)),
+		attribute.Int64("revision", revision),
+		attribute.Int64("limit", limit),
+	)
 
 	compactRevision, currentRevision, err := s.config.Driver.GetCompactRevision(ctx)
 	if err != nil {
@@ -370,13 +368,11 @@ func (s *SQLLog) ttl(ctx context.Context) {
 func (s *SQLLog) Watch(ctx context.Context, key, rangeEnd []byte, startRevision int64) (<-chan []*server.Event, error) {
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Watch", otelName))
 	defer span.End()
-	if span.IsRecording() {
-		span.SetAttributes(
-			attribute.String("key", string(key)),
-			attribute.String("rangeEnd", string(rangeEnd)),
-			attribute.Int64("startRevision", startRevision),
-		)
-	}
+	span.SetAttributes(
+		attribute.String("key", string(key)),
+		attribute.String("rangeEnd", string(rangeEnd)),
+		attribute.Int64("startRevision", startRevision),
+	)
 
 	// starting watching right away so we don't miss anything
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/kine/sqllog/sqllog.go
+++ b/pkg/kine/sqllog/sqllog.go
@@ -43,9 +43,9 @@ func init() {
 }
 
 type Driver interface {
-	List(ctx context.Context, key, end []byte, limit, revision int64) (*sql.Rows, error)
+	List(ctx context.Context, key, rangeEnd []byte, limit, revision int64) (*sql.Rows, error)
 	ListTTL(ctx context.Context, revision int64) (*sql.Rows, error)
-	Count(ctx context.Context, key, end []byte, revision int64) (int64, error)
+	Count(ctx context.Context, key, rangeEnd []byte, revision int64) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	AfterPrefix(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
 	After(ctx context.Context, rev, limit int64) (*sql.Rows, error)
@@ -273,7 +273,7 @@ func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64
 	return currentRevision, result, err
 }
 
-func (s *SQLLog) List(ctx context.Context, key, end []byte, limit, revision int64) (int64, []*server.KeyValue, error) {
+func (s *SQLLog) List(ctx context.Context, key, rangeEnd []byte, limit, revision int64) (int64, []*server.KeyValue, error) {
 	var err error
 
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.List", otelName))
@@ -283,7 +283,7 @@ func (s *SQLLog) List(ctx context.Context, key, end []byte, limit, revision int6
 	}()
 	span.SetAttributes(
 		attribute.String("key", string(key)),
-		attribute.String("end", string(end)),
+		attribute.String("rangeEnd", string(rangeEnd)),
 		attribute.Int64("limit", limit),
 		attribute.Int64("revision", revision),
 	)
@@ -298,7 +298,7 @@ func (s *SQLLog) List(ctx context.Context, key, end []byte, limit, revision int6
 		return currentRevision, nil, server.ErrCompacted
 	}
 
-	rows, err := s.config.Driver.List(ctx, key, end, limit, revision)
+	rows, err := s.config.Driver.List(ctx, key, rangeEnd, limit, revision)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -599,7 +599,7 @@ func canSkipRevision(rev, skip int64, skipTime time.Time) bool {
 	return rev == skip && time.Since(skipTime) > time.Second
 }
 
-func (s *SQLLog) Count(ctx context.Context, key, end []byte, revision int64) (int64, int64, error) {
+func (s *SQLLog) Count(ctx context.Context, key, rangeEnd []byte, revision int64) (int64, int64, error) {
 	var err error
 	ctx, span := otelTracer.Start(ctx, fmt.Sprintf("%s.Count", otelName))
 	defer func() {
@@ -608,7 +608,7 @@ func (s *SQLLog) Count(ctx context.Context, key, end []byte, revision int64) (in
 	}()
 	span.SetAttributes(
 		attribute.String("key", string(key)),
-		attribute.String("end", string(end)),
+		attribute.String("rangeEnd", string(rangeEnd)),
 		attribute.Int64("revision", revision),
 	)
 
@@ -621,7 +621,7 @@ func (s *SQLLog) Count(ctx context.Context, key, end []byte, revision int64) (in
 	} else if revision < compactRevision {
 		return currentRevision, 0, server.ErrCompacted
 	}
-	count, err := s.config.Driver.Count(ctx, key, end, revision)
+	count, err := s.config.Driver.Count(ctx, key, rangeEnd, revision)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/test/compaction_test.go
+++ b/test/compaction_test.go
@@ -79,12 +79,12 @@ func TestCompaction(t *testing.T) {
 				g.Expect(finalSize).To(BeNumerically("<", initialSize))
 
 				// Expect for keys to still be there.
-				rev, count, err := kine.backend.Count(ctx, "key/", "", 0)
+				rev, count, err := kine.backend.Count(ctx, []byte("key/"), []byte("key0"), 0)
 				g.Expect(err).To(BeNil())
 				g.Expect(count).To(Equal(int64(10_000 - 500)))
 
 				// Expect old revisions not to be there anymore.
-				_, _, err = kine.backend.List(ctx, "key/", "", 0, rev-400)
+				_, _, err = kine.backend.List(ctx, []byte("key/"), []byte("key0"), 0, rev-400)
 				g.Expect(err).To(Not(BeNil()))
 			})
 		})


### PR DESCRIPTION
k8s-dqlite can now properly use ranges, so we no longer need to use fragile prefix logic.

Note that in order to properly support etcd range semantics, we need to change the type of the "key" and "limit" arguments to []byte. This means that we'll need to perform a cast as part of the SQL query.

For now we'll only change the List and Count methods. For consistency, we could update the other methods as well in a follow-up patch.

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
