### PR TITLE
Collect inspection reports before deleting the instances

### DIFF
--- a/test/performance/tests/conftest.py
+++ b/test/performance/tests/conftest.py
@@ -187,15 +187,18 @@ def instances(
         LOG.warning("Skipping clean-up of instances, delete them on your own")
         return
 
-    # Cleanup after each test.
-    # We cannot execute _harness_clean() here as this would also
-    # remove the session_instance. The harness ensures that everything is cleaned up
-    # at the end of the test session.
+    # Collect all the reports before initiating the cleanup so that we won't
+    # affect the state of the observed cluster.
     for instance in instances:
         if config.INSPECTION_REPORTS_DIR is not None:
             LOG.debug("Generating inspection reports for test instances")
             _generate_inspection_report(h, instance.id)
 
+    # Cleanup after each test.
+    # We cannot execute _harness_clean() here as this would also
+    # remove the session_instance. The harness ensures that everything is cleaned up
+    # at the end of the test session.
+    for instance in instances:
         h.delete_instance(instance.id)
 
 


### PR DESCRIPTION
We're initiating the instance cleanup before retrieving the inspection reports.

For this reason, k8sd becomes unavailable, affecting the k8s-snap inspection report script, which will no longer be able to retrieve all logs or determine the node role.

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
