### PR TITLE
workflows: remove wait time from perfromance test

### DIFF
--- a/test/performance/templates/api-intensive.yaml
+++ b/test/performance/templates/api-intensive.yaml
@@ -4,6 +4,7 @@ global:
 
 jobs:
   - name: api-intensive
+    preLoadPeriod: 5s
     jobIterations: 100
     qps: 500
     burst: 500
@@ -15,12 +16,12 @@ jobs:
     waitWhenFinished: true
     objects:
       - objectTemplate: configmap.yaml
-        replicas: 10
+        replicas: 50
       - objectTemplate: secret.yaml
-        replicas: 10
+        replicas: 50
   - name: remove-configmaps-secrets
-    qps: 100
-    burst: 100
+    qps: 500
+    burst: 500
     jobType: delete
     objects:
       - kind: ConfigMap


### PR DESCRIPTION
This PR aims at reducing the amount of time taken by the benchmarking job.

If I read the logs correctly, each run (base, head) takes 15 iterations which add up to 60 total iterations:
 - 15 for the 1-node base
 - 15 for the 3-node base
 - 15 for the 1-node head
 - 15 for the 3-node head

Each job waits 1 minute by default before starting. This means that an hour is wasted just waiting for the benchmark to start.