### PR TITLE
CI: use pre-compiled R packages

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set-up R
         run: |
           sudo apt-get install -y r-base
-          sudo Rscript -e 'install.packages(c("ggplot2", "dplyr", "optparse"), repos="https://cloud.r-project.org")'
+          sudo Rscript -e 'install.packages(c("ggplot2", "dplyr", "optparse"), repos="https://cloud.r-project.org", type="both")'
       - name: Install lxd
         uses: canonical/k8s-snap/.github/actions/install-lxd@main
       - name: Download latest k8s-snap


### PR DESCRIPTION
We'll try to avoid building R packages from source whenever possible to reduce the job duration.

https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/install.packages

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
