### PR TITLE
CI: run all k8s-snap tests

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -56,7 +56,7 @@ jobs:
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
           git clone https://github.com/canonical/k8s-snap.git      
-          cd k8s-snap/tests/integration && sg lxd -c 'tox -e integration'
+          cd k8s-snap/tests/integration && sg lxd -c 'tox -e integration -- --tags up_to_weekly'
       - name: Prepare inspection reports
         if: failure()
         run: |


### PR DESCRIPTION
In order to catch regressions and flakes in a timely manner, we'll run all k8s-snap e2e tests (tox -e integration -- --tags up_to_weekly).

Implements: KU-2799

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
