### PR TITLE
CI: cache R dependencies

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -42,8 +42,33 @@ jobs:
           go-version-file: go.mod
       - name: Set-up R
         run: |
-          sudo apt-get install -y r-base
-          sudo Rscript -e 'install.packages(c("ggplot2", "dplyr", "optparse"), repos="https://cloud.r-project.org")'
+          sudo apt-get install -y --no-install-recommends r-base
+
+          sudo mkdir -p /usr/local/lib/R/site-library/
+          # Ensure that actions/cache is allowed to restore the R lib dir.
+          sudo chown $USER /usr/local/lib/R/site-library/
+      - name: Get R cache key
+        id: get-r-cache-key
+        run: |
+          osVersion=$(lsb_release -rs)
+          rVersion=$(dpkg -s r-base | grep Version | cut -d ' ' -f 2)
+          key="r-libs-$osVersion-$rVersion"
+
+          echo "r-cache-key=$key" >> "$GITHUB_OUTPUT"
+      - name: Restore R package cache
+        id: restore-r-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/lib/R/site-library/
+          key: ${{ steps.get-r-cache-key.outputs.r-cache-key }}
+          restore-keys: ${{ steps.get-r-cache-key.outputs.r-cache-key }}
+      - name: Install R dependencies
+        if: steps.restore-r-cache.outputs.cache-hit != 'true'
+        run: |
+          install.packages(
+            c("ggplot2", "dplyr", "optparse"),
+            repos="https://cloud.r-project.org")
+        shell: sudo Rscript {0}
       - name: Install lxd
         uses: canonical/k8s-snap/.github/actions/install-lxd@main
       - name: Download latest k8s-snap


### PR DESCRIPTION
We'll cache the R libraries (/usr/local/lib/R/site-library/) using actions/cache to avoid rebuilding every time, saving a few minutes per run.

We'll also install ``r-base`` using ``--no-install-recommends`` to avoid unnecessary packages.

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
