### PR TITLE
Bug: Use watch poll Rev as "current rev" for watch progress

### DIFF
--- a/pkg/limited/types.go
+++ b/pkg/limited/types.go
@@ -21,6 +21,7 @@ type Backend interface {
 	Update(ctx context.Context, key, value []byte, revision, lease int64) (int64, bool, error)
 	Watch(ctx context.Context, key, rangeEnd []byte, revision int64) (<-chan []*Event, error)
 	DbSize(ctx context.Context) (int64, error)
+	WatchPollRevision() int64
 	CurrentRevision(ctx context.Context) (int64, error)
 	GetCompactRevision(ctx context.Context) (int64, int64, error)
 	DoCompact(ctx context.Context) error


### PR DESCRIPTION
## Description
The bug is with using the “fresh” current revision from the database.
We actually want to pass back the watch poll’s “current revision” instead.
Ex:
We don't want to tell the api-server that we've synced up to current Revision 10 (last rev from DB) when the poll loop is sill at revision 9 and our watcher's actually never sent the event for 10.  That’s our missing event.
