### PR TITLE
CI: use a composite action for rebuilding the snap

### DIFF
--- a/.github/actions/patch-k8s-snap/action.yaml
+++ b/.github/actions/patch-k8s-snap/action.yaml
@@ -1,0 +1,75 @@
+name: Modify a k8s snap, patching k8s-dqlite
+
+inputs:
+  build-k8s-dqlite:
+    description: (Re)build k8s-dqlite
+    type: boolean
+    default: true
+  build-commit:
+    description: Checkout the specified commit before building.
+    type: string
+    default: ""
+  k8s-snap-channel:
+    description: The downloaded k8s-snap channel.
+    type: string
+    default: latest/edge
+  out-snap-path:
+    description: The output k8s snap path.
+    type: string
+    default: k8s-updated.snap
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build k8s-dqlite
+      if: ${{ inputs.build-k8s-dqlite == 'true' }}
+      shell: bash
+      run: |
+        set -ex -o pipefail
+        head=$(git log --format="%H" -n 1)
+
+        if [[ -n "${{ inputs.build-commit }}" ]]; then
+          git fetch origin
+          git reset --hard ${{ inputs.build-commit }}
+        fi
+
+        make static
+
+        if [[ -n "${{ inputs.build-commit }}" ]]; then
+          git reset --hard $head
+        fi
+
+    - name: Download k8s-snap ${{ inputs.k8s-snap-channel }}
+      shell: bash
+      run: |
+        if [[ -f k8s.snap ]]; then
+          echo "k8s.snap already exists, skipping download."
+        else
+          sudo snap download k8s \
+            --channel=${{ inputs.k8s-snap-channel }} \
+            --basename k8s
+        fi
+
+    - name: Unpack Snap
+      shell: bash
+      run: |
+        # To save time, we'll avoid unpacking the snap again.
+        # We only need to replace k8s-dqlite.
+        if [[ -d snap-unpack-dir ]]; then
+          echo "k8s snap already unpacked"
+        else
+          sudo unsquashfs -d snap-unpack-dir k8s.snap
+        fi
+
+    - name: Replace k8s-dqlite binary
+      shell: bash
+      run: |
+          sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
+          sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
+
+    - name: Repack Snap
+      shell: bash
+      run: |
+        sudo mksquashfs snap-unpack-dir \
+          ${{ inputs.out-snap-path}} \
+          -noappend -comp lzo -no-fragments

--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -53,24 +53,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Download latest k8s-snap
-        run: |
-          sudo snap download k8s --channel=latest/edge --basename k8s
       - name: Install lxd
         uses: canonical/k8s-snap/.github/actions/install-lxd@main
-      - name: Build k8s-dqlite
-        run: |
-          make static
-      - name: Unpack Snap
-        run: |
-          sudo unsquashfs -d snap-unpack-dir k8s.snap
-      - name: Replace k8s-dqlite binary
-        run: |
-          sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
-          sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
-      - name: Repack Snap
-        run: |
-          sudo mksquashfs snap-unpack-dir k8s-updated.snap -noappend -comp lzo -no-fragments
+      - name: Patch k8s snap
+        uses: ./.github/actions/patch-k8s-snap
       - name: Running
         env:
           TEST_SNAP: ${{ github.workspace }}/k8s-updated.snap

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -71,29 +71,15 @@ jobs:
         shell: sudo Rscript {0}
       - name: Install lxd
         uses: canonical/k8s-snap/.github/actions/install-lxd@main
-      - name: Download latest k8s-snap
-        run: |
-          sudo snap download k8s --channel=latest/edge --basename k8s
-      - name: Unpack Snap
-        run: |
-          sudo unsquashfs -d snap-unpack-dir k8s.snap
-      - name: Create snap with k8s-dqlite ${{ github.head_ref }} code
-        run: |
-          make static
-          sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
-          sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
-          sudo mksquashfs snap-unpack-dir head.snap -noappend -comp lzo -no-fragments
-      - name: Create snap with k8s-dqlite base-code
-        run: |
-          set -o pipefail
-          git fetch origin $BASE_BRANCH
-          git reset --hard $BASE_SHA
-          make static
-          sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
-          sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
-          sudo mksquashfs snap-unpack-dir base-code.snap -noappend -comp lzo -no-fragments
-      - name: Switch back to target branch
-        run: git reset --hard $TARGET_SHA
+      - name: Patch k8s snap (head)
+        uses: ./.github/actions/patch-k8s-snap
+        with:
+          out-snap-path: head.snap
+      - name: Patch k8s snap (base)
+        uses: ./.github/actions/patch-k8s-snap
+        with:
+          out-snap-path: base-code.snap
+          build-commit: $BASE_SHA
       - name: Run Performance test ${{ github.head_ref }} snap
         env:
           TEST_SNAP: ${{ github.workspace }}/head.snap


### PR DESCRIPTION
We have two jobs that perform the following steps:

* build k8s-dqlite
* download k8s-snap
* unsquash the snap
* patch k8s-dqlite
* recreate the snap file

To simplify the workflows and avoid redundant logic, we'll define a reusable action.

### Thank you for making K8s-dqlite better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
