### PR TITLE
fix: address afterSQL query issue

### DIFF
--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -79,14 +79,12 @@ func init() {
 }
 
 var (
-	columns = "kv.id as theid, kv.name, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease, kv.value, kv.old_value"
-
 	revSQL = `
 		SELECT MAX(rkv.id) AS id
 		FROM kine AS rkv`
 
-	listSQL = fmt.Sprintf(`
-		SELECT %s
+	listSQL = `
+		SELECT id, name, created, deleted, create_revision, prev_revision, lease, value, old_value
 		FROM kine AS kv
 		JOIN (
 			SELECT MAX(mkv.id) as id
@@ -99,7 +97,7 @@ var (
 	    	ON maxkv.id = kv.id
 		WHERE (kv.deleted = 0 OR ?)
 		ORDER BY kv.name ASC, kv.id ASC
-	`, columns)
+	`
 
 	revisionIntervalSQL = `
 		SELECT (
@@ -119,20 +117,19 @@ var (
 			%s
 		)`, listSQL)
 
-	afterSQLPrefix = fmt.Sprintf(`
-		SELECT %s
+	afterSQLPrefix = `
+		SELECT id, name, created, deleted, create_revision, prev_revision, lease, value, old_value
 		FROM kine AS kv
 		WHERE
 			kv.name >= ? AND kv.name < ?
 			AND kv.id > ?
-		ORDER BY kv.id ASC`, columns)
+		ORDER BY kv.id ASC`
 
-	afterSQL = fmt.Sprintf(`
-		SELECT %s
-			FROM kine AS kv
-			WHERE kv.id > ?
-			ORDER BY kv.id ASC
-		`, columns)
+	afterSQL = `
+		SELECT id, name, created, deleted, create_revision, prev_revision, lease, value, old_value
+		FROM kine AS kv
+		WHERE kv.id > ?
+		ORDER BY kv.id ASC`
 
 	deleteRevSQL = `
 		DELETE FROM kine

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -96,8 +96,7 @@ var (
 		) AS maxkv
 	    	ON maxkv.id = kv.id
 		WHERE (kv.deleted = 0 OR ?)
-		ORDER BY kv.name ASC, kv.id ASC
-	`
+		ORDER BY kv.name ASC, kv.id ASC`
 
 	revisionIntervalSQL = `
 		SELECT (


### PR DESCRIPTION
### Address afterSQL query issue

Fixing: https://github.com/canonical/microk8s/issues/4999

The issue is a consequence of this query:
```
columns = "kv.id as theid, kv.name, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease, kv.value, kv.old_value"
afterSQL = fmt.Sprintf(`
	SELECT %s
		FROM kine AS kv
		WHERE kv.id > ?
		ORDER BY kv.id ASC
	`, columns)
```
The resulting error message is:
```level=error msg="fail to get latest events: query (try: 0): theid"```

The issue is selecting `kv.id as theid` and then using `kv.id` in the query.

*Also verify you have:*

* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
