### PR TITLE
Streamline Errors

### DIFF
--- a/pkg/drivers/dqlite/driver.go
+++ b/pkg/drivers/dqlite/driver.go
@@ -31,9 +31,8 @@ type Driver struct {
 }
 
 type DriverConfig struct {
-	DB      database.Interface
-	ErrCode func(error) string
-	App     *app.App
+	DB  database.Interface
+	App *app.App
 }
 
 func NewDriver(ctx context.Context, config *DriverConfig) (*Driver, error) {

--- a/pkg/drivers/sqlite/driver.go
+++ b/pkg/drivers/sqlite/driver.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -248,15 +247,12 @@ func (s Stripped) String() string {
 }
 
 type Driver struct {
-	mu sync.Mutex
-
 	config *DriverConfig
 }
 
 type DriverConfig struct {
-	DB      database.Interface
-	Retry   func(error) bool
-	ErrCode func(error) string
+	DB    database.Interface
+	Retry func(error) bool
 }
 
 func NewDriver(ctx context.Context, config *DriverConfig) (*Driver, error) {
@@ -267,9 +263,6 @@ func NewDriver(ctx context.Context, config *DriverConfig) (*Driver, error) {
 	}
 	if config.DB == nil {
 		return nil, errors.New("db cannot be nil")
-	}
-	if config.ErrCode == nil {
-		config.ErrCode = error.Error
 	}
 	if config.Retry == nil {
 		config.Retry = func(err error) bool {


### PR DESCRIPTION
This PR is suggesting some changes to standardize errors and error wrapping in k8s-dqlite to only expose what's needed while adding necessary error wrappings. 