### PR TITLE
feat: add logging for go-dqlite driver

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,17 +56,16 @@ var (
 		// Uncomment the following line if your bare application
 		// has an action associated with it:
 		Run: func(cmd *cobra.Command, args []string) {
-			if rootCmdOpts.logLevel != "" {
-				level, err := logrus.ParseLevel(rootCmdOpts.logLevel)
-				if err != nil {
-					logrus.WithError(err).Warnf("failed to parse log level %s, proceeding with default log level.", rootCmdOpts.logLevel)
-				} else {
-					logrus.SetLevel(level)
-				}
+			level, err := logrus.ParseLevel(rootCmdOpts.logLevel)
+			if err != nil {
+				logrus.WithError(err).Warnf("failed to parse log level %s, proceeding with default log level.", rootCmdOpts.logLevel)
+			} else {
+				logrus.SetLevel(level)
 			}
 
 			if rootCmdOpts.debug {
 				logrus.SetLevel(logrus.TraceLevel)
+				logrus.Warn("the --debug flag is deprecated, use --log-level instead")
 			}
 
 			if rootCmdOpts.profiling {
@@ -213,7 +212,7 @@ func init() {
 	rootCmd.Flags().StringVar(&rootCmdOpts.listen, "listen", "tcp://127.0.0.1:12379", "endpoint where dqlite should listen to")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.tls, "enable-tls", true, "enable TLS")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.debug, "debug", false, "debug logs")
-	rootCmd.Flags().MarkDeprecated("debug", "use --log-level debug instead")
+	rootCmd.Flags().MarkDeprecated("debug", "use --log-level instead")
 	rootCmd.Flags().StringVar(&rootCmdOpts.logLevel, "log-level", "info", "set the log level")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.profiling, "profiling", false, "enable debug pprof endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingAddress, "profiling-listen", "127.0.0.1:4000", "listen address for pprof endpoint")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ var (
 		listen                    string
 		tls                       bool
 		debug                     bool
+		logLevel                  string
 		profiling                 bool
 		profilingAddress          string
 		profilingDir              string
@@ -55,6 +56,15 @@ var (
 		// Uncomment the following line if your bare application
 		// has an action associated with it:
 		Run: func(cmd *cobra.Command, args []string) {
+			if rootCmdOpts.logLevel != "" {
+				level, err := logrus.ParseLevel(rootCmdOpts.logLevel)
+				if err != nil {
+					logrus.WithError(err).Fatalf("failed to parse log level %s", rootCmdOpts.logLevel)
+				} else {
+					logrus.SetLevel(level)
+				}
+			}
+
 			if rootCmdOpts.debug {
 				logrus.SetLevel(logrus.TraceLevel)
 			}
@@ -203,6 +213,8 @@ func init() {
 	rootCmd.Flags().StringVar(&rootCmdOpts.listen, "listen", "tcp://127.0.0.1:12379", "endpoint where dqlite should listen to")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.tls, "enable-tls", true, "enable TLS")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.debug, "debug", false, "debug logs")
+	rootCmd.Flags().MarkDeprecated("debug", "use --log-level debug instead")
+	rootCmd.Flags().StringVar(&rootCmdOpts.logLevel, "log-level", "error", "set the log level")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.profiling, "profiling", false, "enable debug pprof endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingAddress, "profiling-listen", "127.0.0.1:4000", "listen address for pprof endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingDir, "profiling-dir", "", "directory to use for profiling data")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ var (
 			if rootCmdOpts.logLevel != "" {
 				level, err := logrus.ParseLevel(rootCmdOpts.logLevel)
 				if err != nil {
-					logrus.WithError(err).Fatalf("failed to parse log level %s", rootCmdOpts.logLevel)
+					logrus.WithError(err).Warnf("failed to parse log level %s, proceeding with default log level.", rootCmdOpts.logLevel)
 				} else {
 					logrus.SetLevel(level)
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,7 +214,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootCmdOpts.tls, "enable-tls", true, "enable TLS")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.debug, "debug", false, "debug logs")
 	rootCmd.Flags().MarkDeprecated("debug", "use --log-level debug instead")
-	rootCmd.Flags().StringVar(&rootCmdOpts.logLevel, "log-level", "error", "set the log level")
+	rootCmd.Flags().StringVar(&rootCmdOpts.logLevel, "log-level", "info", "set the log level")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.profiling, "profiling", false, "enable debug pprof endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingAddress, "profiling-listen", "127.0.0.1:4000", "listen address for pprof endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingDir, "profiling-dir", "", "directory to use for profiling data")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,8 @@ The following configuration options are available listed in a table format:
 | `--storage-dir` | The directory to store the Dqlite data | `/var/tmp/k8s-dqlite/` |
 | `--listen` | The endpoint where Dqlite should listen to | `tcp://127.0.0.1:12379` |
 | `--enable-tls` | Enable TLS | `true` |
-| `--debug` | Enable debug logs | `false` |
+| `--debug` | `DEPRECIATED` | `false` |
+| `--log-level` | The log level to use (debug, info, warn, error, fatal) | `info` |
 | `--profiling` | Enable debug pprof endpoint | `false` |
 | `--profiling-dir` | Directory to use for profiling data | - |
 | `--profiling-listen` | The address to listen for pprof endpoint | `127.0.0.1:4000` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ The following configuration options are available listed in a table format:
 | `--storage-dir` | The directory to store the Dqlite data | `/var/tmp/k8s-dqlite/` |
 | `--listen` | The endpoint where Dqlite should listen to | `tcp://127.0.0.1:12379` |
 | `--enable-tls` | Enable TLS | `true` |
-| `--debug` | `DEPRECIATED` | `false` |
+| `--debug` | `DEPRECIATED`: Enable debug logs | `false` |
 | `--log-level` | The log level to use (debug, info, warn, error, fatal) | `info` |
 | `--profiling` | Enable debug pprof endpoint | `false` |
 | `--profiling-dir` | Directory to use for profiling data | - |

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,7 +93,7 @@ journalctl -u snap.k8s.k8s-dqlite -f
 
 Or use `microk8s.daemon-k8s-dqlite` for MicroK8s.
 
-To debug, you can set the `--debug` flag to true as explained in the [configuration](configuration.md) documentation.
+To debug, you can set the `--log-level` flag to the desired level as explained in the [configuration](configuration.md) documentation.
 
 ## Connecting to the Dqlite Database
 
@@ -117,5 +117,5 @@ Sometimes it is helpful to get insights into what is happening in the dqlite lay
 To do this, you can enable debug logs. Add debug logs by editing
 `/var/snap/k8s/common/args/k8s-dqlite-env` or `/var/snap/microk8s/current/args/k8s-dqlite-env` and uncomment `LIBDQLITE_TRACE=1` and `LIBRAFT_TRACE=1`. Then restart the k8s-dqlite service and check the k8s-dqlite logs.
 
-To enable k8s-dqlite debug logging, add ``--debug`` to
+To increase the log level in k8s-dqlite add ``--log-level=debug`` to
 ``/var/snap/k8s/common/args/k8s-dqlite``.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -120,9 +120,10 @@ func New(
 	connectionPoolConfig *ConnectionPoolConfig,
 	watchQueryTimeout time.Duration,
 	watchProgressNotifyInterval time.Duration,
-
 ) (*Server, error) {
-	options := []app.Option{}
+	options := []app.Option{
+		app.WithLogFunc(appLog),
+	}
 	serverConfig := &ServerConfig{
 		ListenAddress: listen,
 
@@ -505,6 +506,25 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 	close(s.mustStopCh)
 	return nil
+}
+
+func logrusLogLevel(level client.LogLevel) logrus.Level {
+	switch level {
+	case client.LogError:
+		return logrus.ErrorLevel
+	case client.LogWarn:
+		return logrus.WarnLevel
+	case client.LogInfo:
+		return logrus.InfoLevel
+	case client.LogDebug:
+		return logrus.DebugLevel
+	default:
+		return logrus.TraceLevel
+	}
+}
+
+func appLog(level client.LogLevel, format string, args ...interface{}) {
+	logrus.StandardLogger().Logf(logrusLogLevel(level), format, args...)
 }
 
 var _ Instance = &Server{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -121,8 +121,10 @@ func New(
 	watchQueryTimeout time.Duration,
 	watchProgressNotifyInterval time.Duration,
 ) (*Server, error) {
+	level := logrus.GetLevel()
 	options := []app.Option{
 		app.WithLogFunc(appLog),
+		app.WithTracing(clientLogLevel(level)),
 	}
 	serverConfig := &ServerConfig{
 		ListenAddress: listen,
@@ -520,6 +522,22 @@ func logrusLogLevel(level client.LogLevel) logrus.Level {
 		return logrus.DebugLevel
 	default:
 		return logrus.TraceLevel
+	}
+}
+
+// ToLoggingLevel converts a logrus.Level to your custom logging.Level.
+func clientLogLevel(logrusLevel logrus.Level) client.LogLevel {
+	switch logrusLevel {
+	case logrus.ErrorLevel:
+		return client.LogError
+	case logrus.WarnLevel:
+		return client.LogWarn
+	case logrus.InfoLevel:
+		return client.LogInfo
+	case logrus.DebugLevel:
+		return client.LogDebug
+	default:
+		return client.LogNone
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -121,11 +121,15 @@ func New(
 	watchQueryTimeout time.Duration,
 	watchProgressNotifyInterval time.Duration,
 ) (*Server, error) {
-	level := logrus.GetLevel()
 	options := []app.Option{
 		app.WithLogFunc(appLog),
-		app.WithTracing(clientLogLevel(level)),
 	}
+
+	level := logrus.GetLevel()
+	if level == logrus.TraceLevel {
+		options = append(options, app.WithTracing(client.LogDebug))
+	}
+
 	serverConfig := &ServerConfig{
 		ListenAddress: listen,
 
@@ -525,23 +529,8 @@ func logrusLogLevel(level client.LogLevel) logrus.Level {
 	}
 }
 
-// ToLoggingLevel converts a logrus.Level to your custom logging.Level.
-func clientLogLevel(logrusLevel logrus.Level) client.LogLevel {
-	switch logrusLevel {
-	case logrus.ErrorLevel:
-		return client.LogError
-	case logrus.WarnLevel:
-		return client.LogWarn
-	case logrus.InfoLevel:
-		return client.LogInfo
-	case logrus.DebugLevel:
-		return client.LogDebug
-	default:
-		return client.LogNone
-	}
-}
-
 func appLog(level client.LogLevel, format string, args ...interface{}) {
+	format = fmt.Sprintf("[go-dqlite] %s", format)
 	logrus.StandardLogger().Logf(logrusLogLevel(level), format, args...)
 }
 


### PR DESCRIPTION
This PR adds logging for the go-dqlite driver.
Also adds log-levels that can be set through the root command options. Depreciates --debug flag.

Example:
```
ubuntu@louise-dev2:~/k8s-dqlite$ sudo ./bin/static/k8s-dqlite     --storage-dir /var/snap/k8s/common/var/lib/k8s-dqlite     --listen unix:///var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock --log-level=debug
INFO[0000] configure dqlite failure domain               failure-domain=0
INFO[0000] disable TLS ClientSessionCache               
INFO[0000] enable TLS                                    min_tls_version=tls12
INFO[0000] configure dqlite raft snapshot parameters     threshold=512 trailing=4096
DEBU[0000] [go-dqlite] new connection from 192.168.105.17:50638 
DEBU[0000] [go-dqlite] attempt 1: server 192.168.105.17:9000: connected on fallback path 
DEBU[0000] [go-dqlite] new connection from 192.168.105.17:50644 
INFO[0000] started dqlite                                address="192.168.105.17:9000" id=3297041220608546238
DEBU[0000] starting k8s-dqlite server                    config="&{unix:///var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock 5m0s 1s 20s 5s { /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key}}"
DEBU[0000] [go-dqlite] new connection from 192.168.105.17:50660 
DEBU[0000] [go-dqlite] attempt 1: server 192.168.105.17:9000: connected on fallback path 
```