### PR TITLE
workflows: remove wait time from performance test (#252)

### DIFF
--- a/test/performance/templates/api-intensive.yaml
+++ b/test/performance/templates/api-intensive.yaml
@@ -5,6 +5,7 @@ metricsEndpoints:
 
 jobs:
   - name: api-intensive
+    preLoadPeriod: 5s
     jobIterations: 100
     qps: 500
     burst: 500
@@ -15,14 +16,14 @@ jobs:
     waitWhenFinished: true
     objects:
       - objectTemplate: configmap.yaml
-        replicas: 10
+        replicas: 50
         wait: true
       - objectTemplate: secret.yaml
-        replicas: 10
+        replicas: 50
         wait: true
   - name: remove-configmaps-secrets
-    qps: 100
-    burst: 100
+    qps: 500
+    burst: 500
     jobType: delete
     objects:
       - kind: ConfigMap


### PR DESCRIPTION
# workflows: remove wait time from performance test
(cherry picked from commit f88169313c034bd94bb056960e6b6f91c4e473ee)

This PR aims at reducing the amount of time taken by the benchmarking job.

If I read the logs correctly, each run (base, head) takes 15 iterations which add up to 60 total iterations:
 - 15 for the 1-node base
 - 15 for the 3-node base
 - 15 for the 1-node head
 - 15 for the 3-node head

Each job waits 1 minute by default before starting. This means that an hour is wasted just waiting for the benchmark to start.