### PR TITLE
feat: Use debug to enable go-dqlite debug mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,6 +146,7 @@ var (
 				&rootCmdOpts.connectionPoolConfig,
 				rootCmdOpts.watchQueryTimeout,
 				rootCmdOpts.watchProgressNotifyInterval,
+				rootCmdOpts.debug,
 			)
 			if err != nil {
 				logrus.WithError(err).Fatal("failed to create server")


### PR DESCRIPTION
### Overview

This PR passes the `debug` option to server initialization to be used to enable `go-dqlite` debug mode.
The `logEverythingFunc` is inspired by the default log func of go-dqlite.