### PR TITLE
CI: use canonical lxd setup

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -54,7 +54,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install lxd
-        uses: canonical/k8s-snap/.github/actions/install-lxd@main
+        uses: canonical/setup-lxd@v0.1.3
+        with:
+          bridges: "lxdbr0,dualstack-br0,ipv6-br0"
       - name: Patch k8s snap
         uses: ./.github/actions/patch-k8s-snap
       - name: Running

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -70,7 +70,9 @@ jobs:
             repos="https://cloud.r-project.org")
         shell: sudo Rscript {0}
       - name: Install lxd
-        uses: canonical/k8s-snap/.github/actions/install-lxd@main
+        uses: canonical/setup-lxd@v0.1.3
+        with:
+          bridges: "lxdbr0"
       - name: Patch k8s snap (head)
         uses: ./.github/actions/patch-k8s-snap
         with:


### PR DESCRIPTION
## Update lxd setup workaround in CI

Use canonical setup lxd action instead of k8s-snap action which was removed: https://github.com/canonical/k8s-snap/pull/1422.