### PR TITLE
[backport] ci: use canonical lxd setup

### DIFF
--- a/.github/workflows/k8s-snap-integration.yaml
+++ b/.github/workflows/k8s-snap-integration.yaml
@@ -34,7 +34,9 @@ jobs:
         run: |
           sudo snap download k8s --channel=latest/edge --basename k8s
       - name: Install lxd
-        uses: canonical/k8s-snap/.github/actions/install-lxd@main
+        uses: canonical/setup-lxd@v0.1.3
+        with:
+          bridges: "lxdbr0,dualstack-br0,ipv6-br0"
       - name: Build k8s-dqlite
         run: |
           make static

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -45,7 +45,9 @@ jobs:
           sudo apt-get install -y r-base
           sudo Rscript -e 'install.packages(c("ggplot2", "dplyr", "optparse"), repos="https://cloud.r-project.org")'
       - name: Install lxd
-        uses: canonical/k8s-snap/.github/actions/install-lxd@main
+        uses: canonical/setup-lxd@v0.1.3
+        with:
+          bridges: "lxdbr0"
       - name: Download latest k8s-snap
         run: |
           sudo snap download k8s --channel=latest/edge --basename k8s


### PR DESCRIPTION
## Backport CI fix
Backport of https://github.com/canonical/k8s-dqlite/pull/290.