### PR TITLE
[backport v1.3] fix: never drop lease deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/canonical/go-dqlite/v2 v2.0.0
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
@@ -29,7 +30,6 @@ require (
 require (
 	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect

--- a/pkg/kine/logstructured/logstructured.go
+++ b/pkg/kine/logstructured/logstructured.go
@@ -3,11 +3,13 @@ package logstructured
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/canonical/k8s-dqlite/pkg/kine/server"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -252,13 +254,42 @@ func (l *LogStructured) ttl(ctx context.Context) {
 	mutex := &sync.Mutex{}
 	for event := range l.ttlEvents(ctx) {
 		go func(event *server.Event) {
+			// add some jitter to avoid ttl expiry and deletion on all nodes at the same time with the goal of
+			// one of them succeeding if the DB is under high load (busy)
+			jitterDelay := time.Duration(rand.Intn(1000)) * time.Millisecond // Jitter up to 1 second as api-server does not expect sub-second precision
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Duration(event.KV.Lease) * time.Second):
+			case <-time.After(time.Duration(event.KV.Lease)*time.Second + jitterDelay):
 			}
-			mutex.Lock()
-			l.Delete(ctx, event.KV.Key, event.KV.ModRevision)
+
+			deleteLease := func() error {
+				// retry until we succeed or context is cancelled, if another node has already deleted the key the delete will not return an error and we will exit the retry loop
+				mutex.Lock()
+				rev, deleted, err := l.Delete(ctx, event.KV.Key, event.KV.ModRevision)
+				mutex.Unlock()
+				if err != nil {
+					logrus.Errorf("failed to delete %s for TTL: %v, retrying", event.KV.Key, err)
+					return err
+				}
+				if deleted {
+					logrus.Debugf("deleted %s for TTL, revRet=%d", event.KV.Key, rev)
+				}
+				return nil
+			}
+
+			b := backoff.NewExponentialBackOff()
+			b.InitialInterval = 100 * time.Millisecond
+			b.RandomizationFactor = 0.5
+			b.Multiplier = 1.5
+			b.MaxInterval = 5 * time.Second
+			b.MaxElapsedTime = 0 // retry indefinitely
+			b.Reset()
+
+			err := backoff.Retry(deleteLease, backoff.WithContext(b, ctx))
+			if err != nil {
+				logrus.Errorf("failed to delete %s for TTL after retries: %v", event.KV.Key, err)
+			}
 			mutex.Unlock()
 		}(event)
 	}


### PR DESCRIPTION
## Never drop lease deletion
We have a bug where essentially if the lease deletion fails on all nodes of the cluster the deletion is not retried unless the k8s-dqlite service is restarted in which case the lease removal and its timer are restarted.
This patch introduces an unlimited retry back-off for the lease deletion.

Backport of https://github.com/canonical/k8s-dqlite/pull/298