### PR TITLE
ci: fix also replace dqlite

### DIFF
--- a/.github/actions/patch-k8s-snap/action.yaml
+++ b/.github/actions/patch-k8s-snap/action.yaml
@@ -61,11 +61,13 @@ runs:
           sudo unsquashfs -d snap-unpack-dir k8s.snap
         fi
 
-    - name: Replace k8s-dqlite binary
+    - name: Replace k8s-dqlite dqlite binary
       shell: bash
       run: |
           sudo cp ./bin/static/k8s-dqlite snap-unpack-dir/bin/k8s-dqlite
           sudo chmod o+r snap-unpack-dir/bin/k8s-dqlite
+          sudo cp ./bin/static/dqlite snap-unpack-dir/bin/dqlite
+          sudo chmod o+r snap-unpack-dir/bin/dqlite
 
     - name: Repack Snap
       shell: bash


### PR DESCRIPTION
## ci: fix also replace dqlite binary

Currently, we only replace the k8s-dqlite binary in the performance and integration test. This PR also replaces the dqlite binary in the test