### PR TITLE
fix: remove serializable unsupported

### DIFF
--- a/pkg/limited/server.go
+++ b/pkg/limited/server.go
@@ -50,10 +50,6 @@ func (k *KVServerBridge) Range(ctx context.Context, r *etcdserverpb.RangeRequest
 		return nil, unsupported("sortTarget")
 	}
 
-	if r.Serializable {
-		return nil, unsupported("serializable")
-	}
-
 	if r.KeysOnly {
 		return nil, unsupported("keysOnly")
 	}


### PR DESCRIPTION
## fix: remove serializable unsupported
Dqlite txn are always serializable:

> They are serializable because Dqlite allows at most one writer at a time and readers always observe a consistent (i.e. committed) snapshot of the database, therefore transactions can’t “interleave”.


 See [consistency-model](https://canonical.com/dqlite/docs/explanation/consistency-model).