### PR TITLE
feat: better cluster stability (RolesAdjustmentFrequency, node join)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,24 +19,25 @@ import (
 
 var (
 	rootCmdOpts struct {
-		dir                       string
-		listen                    string
-		tls                       bool
-		debug                     bool
-		logLevel                  string
-		profiling                 bool
-		profilingAddress          string
-		profilingDir              string
-		diskMode                  bool
-		clientSessionCacheSize    uint
-		minTLSVersion             string
-		metrics                   bool
-		metricsAddress            string
-		otel                      bool
-		otelAddress               string
-		otelDir                   string
-		otelSpanNameFilter        string
-		otelSpanMinDurationFilter string
+		dir                            string
+		listen                         string
+		tls                            bool
+		debug                          bool
+		logLevel                       string
+		profiling                      bool
+		profilingAddress               string
+		profilingDir                   string
+		diskMode                       bool
+		dqliteRolesAdjustmentFrequency time.Duration
+		clientSessionCacheSize         uint
+		minTLSVersion                  string
+		metrics                        bool
+		metricsAddress                 string
+		otel                           bool
+		otelAddress                    string
+		otelDir                        string
+		otelSpanNameFilter             string
+		otelSpanMinDurationFilter      string
 
 		connectionPoolConfig server.ConnectionPoolConfig
 
@@ -147,6 +148,7 @@ var (
 				rootCmdOpts.listen,
 				rootCmdOpts.tls,
 				rootCmdOpts.diskMode,
+				rootCmdOpts.dqliteRolesAdjustmentFrequency,
 				rootCmdOpts.clientSessionCacheSize,
 				rootCmdOpts.minTLSVersion,
 				rootCmdOpts.watchAvailableStorageInterval,
@@ -218,6 +220,7 @@ func init() {
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingAddress, "profiling-listen", "127.0.0.1:4000", "listen address for pprof endpoint")
 	rootCmd.Flags().StringVar(&rootCmdOpts.profilingDir, "profiling-dir", "", "directory to use for profiling data")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.diskMode, "disk-mode", false, "(experimental) run dqlite store in disk mode")
+	rootCmd.Flags().DurationVar(&rootCmdOpts.dqliteRolesAdjustmentFrequency, "dqlite-roles-adjustment-frequency", 10*time.Second, "sets the frequency at which the current cluster leader will check node roles and perfoms promotions/demotions")
 	rootCmd.Flags().UintVar(&rootCmdOpts.clientSessionCacheSize, "tls-client-session-cache-size", 0, "ClientCacheSession size for dial TLS config")
 	rootCmd.Flags().StringVar(&rootCmdOpts.minTLSVersion, "min-tls-version", "tls12", "Minimum TLS version for dqlite endpoint (tls10|tls11|tls12|tls13). Default is tls12")
 	rootCmd.Flags().BoolVar(&rootCmdOpts.metrics, "metrics", false, "enable metrics endpoint")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ The following configuration options are available listed in a table format:
 | `--profiling-dir` | Directory to use for profiling data | - |
 | `--profiling-listen` | The address to listen for pprof endpoint | `127.0.0.1:4000` |
 | `--disk-mode` | (Experimental) Run Dqlite store in disk mode | `false` |
+| `--dqlite-roles-adjustment-frequency` | sets the frequency at which the current cluster leader will check node roles and perfoms promotions/demotions | `5s` | 
 | `--tls-client-session-cache-size` | ClientCacheSession size for dial TLS config | `0` |
 | `--min-tls-version` | Minimum TLS version for Dqlite endpoint supported values: (tls10, tls11, tls12, tls13) | `tls12` |
 | `--metrics` | Enable metrics endpoint | `false` |

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -112,6 +112,7 @@ func New(
 	listen string,
 	enableTLS bool,
 	diskMode bool,
+	dqliteRolesAdjustmentFrequency time.Duration,
 	clientSessionCacheSize uint,
 	minTLSVersion string,
 	watchAvailableStorageInterval time.Duration,
@@ -341,8 +342,8 @@ func New(
 		logrus.Warn("dqlite disk mode operation is current at an experimental state and MUST NOT be used in production. Expect data loss.")
 	}
 
-	// drop role adjustment frequency from the default 30s to 10s to make Dqlite more responsive to role changes
-	app.WithRolesAdjustmentFrequency(10 * time.Second)
+	logrus.WithField("dqliteRolesAdjustmentFrequency", dqliteRolesAdjustmentFrequency).Info("configure dqlite role adjustment frequency")
+	app.WithRolesAdjustmentFrequency(dqliteRolesAdjustmentFrequency)
 	// FIXME: this also starts dqlite. It should be moved to `Start`.
 	app, err := app.New(dir, options...)
 	if err != nil {


### PR DESCRIPTION
### Better cluster stability (RolesAdjustmentFrequency, node join)

Context: We've seen [test](https://github.com/canonical/k8s-snap/actions/runs/15492797421/job/43784305600?pr=1513) failures (e.g. test_disabled_feature_upgrade_controller) caused by a race condition where a node is joined to the cluster and a snap refresh happens immediately after.

This PR makes node-joins more robust by:
- reducing the dqliteRolesAdjustmentFrequency to 10s (from 30s Dqlite default). 
  - The value is generally set to 5-10 times more than election_timeout. Applies in scenarios where with a few subsequent failures there might be scenarios when a few client may observe 2-3 unavailable leaders and those will get retried. The retry will happen when the node roles are adjusted. This value is recommended to us by the Dqlite team. The value should be 5-10 times more than the Dqlite election_timeout.
- only removing the cluster init.yaml after Dqlite was successfully able to start.


* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
