### PR TITLE
fix: lease test flakiness

### DIFF
--- a/test/lease_test.go
+++ b/test/lease_test.go
@@ -44,7 +44,7 @@ func TestLease(t *testing.T) {
 				resp, err := server.client.Get(ctx, leaseKey, clientv3.WithRange(""))
 				g.Expect(err).To(BeNil())
 				return resp.Kvs
-			}, time.Duration(ttlSeconds*2)*time.Second, testExpirePollPeriod, ctx).Should(BeEmpty())
+			}, time.Duration(ttlSeconds*2100)*time.Millisecond, testExpirePollPeriod, ctx).Should(BeEmpty())
 		})
 	}
 }


### PR DESCRIPTION
The lease unit test creates a key with one second TTL and then waits two seconds for the key to be removed before timing out. Since there is a [random jitter](https://github.com/canonical/k8s-dqlite/blob/fbab30e641aab2e0e9018505ea658fe50f90b868/pkg/backend/internal/backend/ttl.go#L90-L92) with sets at most one second gap between expiry of the key and removing it, the jitter may cause the test to timeout and introduce a flakiness. This PR adds another 100ms to the test timeout to avoid such possibility. 