### PR TITLE
backport: latest bug fixes v1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bin/static/k8s-dqlite: $(DQLITE_BUILD_SCRIPTS_DIR)/.deps/static/lib/libdqlite.a 
 
 bin/static/dqlite: $(DQLITE_BUILD_SCRIPTS_DIR)/.deps/static/lib/libdqlite.a
 	mkdir -p bin/static
-	GOBIN=$(shell pwd)/bin/static $(DQLITE_BUILD_SCRIPTS_DIR)/static-go-install.sh github.com/canonical/go-dqlite/cmd/dqlite@v1.20.0
+	GOBIN=$(shell pwd)/bin/static $(DQLITE_BUILD_SCRIPTS_DIR)/static-go-install.sh github.com/canonical/go-dqlite/v2/cmd/dqlite@v2.0.1
 
 ## Dynamic Builds
 dynamic: bin/dynamic/k8s-dqlite bin/dynamic/dqlite
@@ -44,7 +44,7 @@ bin/dynamic/k8s-dqlite: bin/dynamic/lib/libdqlite.so $(GO_SOURCES)
 
 bin/dynamic/dqlite: bin/dynamic/lib/libdqlite.so
 	mkdir -p bin/dynamic
-	GOBIN=$(shell pwd)/bin/dynamic $(DQLITE_BUILD_SCRIPTS_DIR)/dynamic-go-install.sh github.com/canonical/go-dqlite/cmd/dqlite@v1.20.0
+	GOBIN=$(shell pwd)/bin/dynamic $(DQLITE_BUILD_SCRIPTS_DIR)/dynamic-go-install.sh github.com/canonical/go-dqlite/v2/cmd/dqlite@v2.0.1
 
 ## Cleanup
 clean:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/canonical/k8s-dqlite
 go 1.21
 
 require (
-	github.com/canonical/go-dqlite v1.22.0
+	github.com/canonical/go-dqlite v2.0.0
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
@@ -30,7 +31,6 @@ require (
 require (
 	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/k8s-dqlite
 go 1.21
 
 require (
-	github.com/canonical/go-dqlite v2.0.0
+	github.com/canonical/go-dqlite/v2 v2.0.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/onsi/gomega v1.27.10

--- a/go.sum
+++ b/go.sum
@@ -49,10 +49,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
-github.com/canonical/go-dqlite v1.22.0 h1:DuJmfcREl4gkQJyvZzjl2GHFZROhbPyfdjDRQXpkOyw=
-github.com/canonical/go-dqlite v1.22.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
+github.com/canonical/go-dqlite/v2 v2.0.1 h1:C5A+MioYkjew5rG8apjVYwGYIpKKkkC1FlnL4cBLGaE=
+github.com/canonical/go-dqlite/v2 v2.0.1/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/kine/drivers/generic/generic.go
+++ b/pkg/kine/drivers/generic/generic.go
@@ -576,8 +576,8 @@ func (d *Generic) tryCompact(ctx context.Context, start, end int64) (err error) 
 	if _, err = tx.ExecContext(ctx, `
 		DELETE FROM kine
 		WHERE deleted = 1
-			AND ? < id AND id <= ?
-	`, start, end); err != nil {
+			AND id <= ?
+	`, end); err != nil {
 		return err
 	}
 
@@ -742,15 +742,6 @@ func (d *Generic) After(ctx context.Context, rev, limit int64) (*sql.Rows, error
 		return d.query(ctx, "after_sql_limit", sql, rev, limit)
 	}
 	return d.query(ctx, "after_sql", sql, rev)
-}
-
-func (d *Generic) Fill(ctx context.Context, revision int64) error {
-	_, err := d.execute(ctx, "fill_sql", d.FillSQL, revision, fmt.Sprintf("gap-%d", revision), 0, 1, 0, 0, 0, nil, nil)
-	return err
-}
-
-func (d *Generic) IsFill(key string) bool {
-	return strings.HasPrefix(key, "gap-")
 }
 
 func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (id int64, err error) {


### PR DESCRIPTION
## This PR backports relevant bug fixes

```
commit fd1f8791b8f43d28d5c26950527af75feea776bb (HEAD -> v1.3, tag: v1.3.3, origin/v1.3)
Author: Louise K. Schmidtgen <louise.schmidtgen@canonical.com>
Date:   Wed Aug 6 08:50:12 2025 +0200

    fix: rm gap fill logic and clean up old gap fills in compaction (#313)
    
    * fix: rm gap fill logic and clean up old gap fills in compaction
    
    * CI: add datastore-type to bootstrap config (#309)

commit 8120df73728a8c1116228f4d461c98b627521190
Author: Louise K. Schmidtgen <louise.schmidtgen@canonical.com>
Date:   Fri Jun 13 14:09:39 2025 +0200

    fix: [backport v1.3] go-dqlite v2.0.1 (#303)

commit a434e8466ac8af46f6e9f2deff575a9ff9d23fba (KU-3614/v1.3-go-dqlite-v3.0.1)
Author: Louise K. Schmidtgen <louise.schmidtgen@canonical.com>
Date:   Tue Jun 10 09:07:49 2025 +0200

    [backport v1.3] fix: never drop lease deletion (#297)

```