### PR TITLE
chore: Pass Go tags using environment variables

### DIFF
--- a/hack/dynamic-go-build.sh
+++ b/hack/dynamic-go-build.sh
@@ -4,7 +4,10 @@ DIR="$(realpath `dirname "${0}"`)"
 
 . "${DIR}/dynamic-dqlite.sh"
 
+# Default tags if TAGS environment variable is not set
+TAGS="${TAGS:-libsqlite3}"
+
 go build \
-  -tags libsqlite3 \
+  -tags "${TAGS}" \
   -ldflags '-extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"

--- a/hack/dynamic-go-install.sh
+++ b/hack/dynamic-go-install.sh
@@ -4,7 +4,10 @@ DIR="$(realpath `dirname "${0}"`)"
 
 . "${DIR}/dynamic-dqlite.sh"
 
+# Default tags if TAGS environment variable is not set
+TAGS="${TAGS:-libsqlite3}"
+
 go install \
-  -tags libsqlite3 \
+  -tags "${TAGS}" \
   -ldflags '-s -w -extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"


### PR DESCRIPTION
### Overview

This PR enables passing Go build tags using environment variables instead of hard-coding them.