### PR TITLE
chore: [Backport 1.7] Pass Go tags using environment variables (#316)

### DIFF
--- a/hack/dynamic-go-build.sh
+++ b/hack/dynamic-go-build.sh
@@ -4,7 +4,10 @@ DIR="$(realpath `dirname "${0}"`)"
 
 . "${DIR}/dynamic-dqlite.sh"
 
+# Default tags if TAGS environment variable is not set
+TAGS="${TAGS:-libsqlite3}"
+
 go build \
-  -tags libsqlite3 \
+  -tags "${TAGS}" \
   -ldflags '-extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"

--- a/hack/dynamic-go-install.sh
+++ b/hack/dynamic-go-install.sh
@@ -4,7 +4,10 @@ DIR="$(realpath `dirname "${0}"`)"
 
 . "${DIR}/dynamic-dqlite.sh"
 
+# Default tags if TAGS environment variable is not set
+TAGS="${TAGS:-libsqlite3}"
+
 go install \
-  -tags libsqlite3 \
+  -tags "${TAGS}" \
   -ldflags '-s -w -extldflags "-Wl,-rpath,$ORIGIN/lib -Wl,-rpath,$ORIGIN/../lib"' \
   "${@}"


### PR DESCRIPTION
### Overview

This PR backports https://github.com/canonical/k8s-dqlite/pull/316 that enables passing Go build tags.