### PR TITLE
feat: add controlled autovacuum for small databases

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+IndentWidth: 4

--- a/pkg/backend/dqlite/driver.go
+++ b/pkg/backend/dqlite/driver.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/canonical/go-dqlite/v3"
 	"github.com/canonical/go-dqlite/v3/app"
 	"github.com/canonical/go-dqlite/v3/driver"
 	"github.com/canonical/k8s-dqlite/pkg/backend/sqlite"
@@ -14,13 +13,6 @@ import (
 	"github.com/mattn/go-sqlite3"
 	"github.com/sirupsen/logrus"
 )
-
-func init() {
-	// We assume SQLite will be used multi-threaded
-	if err := dqlite.ConfigMultiThread(); err != nil {
-		panic(fmt.Errorf("failed to set dqlite multithreaded mode: %v", err))
-	}
-}
 
 type Driver struct {
 	*sqlite.Driver

--- a/pkg/backend/sqlite/driver.go
+++ b/pkg/backend/sqlite/driver.go
@@ -419,7 +419,7 @@ FROM pragma_page_count(), pragma_freelist_count(), pragma_page_size()`)
 	}
 
 	// If the database is small, we can have an initial VACUUM operation which we know it
-	// will always yeald a transaction smaller than its initial size and as such will not
+	// will always yield a transaction smaller than its initial size and as such will not
 	// create big problems when using RAFT protocol.
 	if size <= autovacuumThreshold {
 		if _, err := conn.ExecContext(ctx, "PRAGMA auto_vacuum = FULL; VACUUM"); err != nil {

--- a/pkg/backend/sqlite/extensions.c
+++ b/pkg/backend/sqlite/extensions.c
@@ -1,0 +1,60 @@
+#include "extensions.h"
+
+#include <assert.h>
+#include <sqlite3.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+
+#define UNUSED(x) (void)(x)
+
+struct vacuum_config_s {
+    size_t percent;
+    size_t max_pages;
+} vacuum_config;
+
+static unsigned int autovacuum_pages_callback(void *pClientData,
+                                              const char *zSchema,
+                                              unsigned int nDbPage,
+                                              unsigned int nFreePage,
+                                              unsigned int nBytePerPage) {
+    UNUSED(pClientData);
+    UNUSED(zSchema);
+    UNUSED(nBytePerPage);
+
+    assert(nDbPage >= nFreePage);
+
+    unsigned int keep_amount =
+        (nDbPage - nFreePage) * vacuum_config.percent / 100;
+    if (nFreePage < keep_amount) {
+        return 0;
+    }
+
+    unsigned int free_amount = nFreePage - keep_amount;
+    if (free_amount > vacuum_config.max_pages) {
+        free_amount = vacuum_config.max_pages;
+    }
+    return free_amount;
+}
+
+static sqlite3_error auto_instrument_connection(
+    sqlite3 *connection, const char **pzErrMsg,
+    const struct sqlite3_api_routines *pThunk) {
+    UNUSED(pzErrMsg);
+    UNUSED(pThunk);
+
+    return sqlite3_autovacuum_pages(connection, autovacuum_pages_callback, NULL,
+                                    NULL);
+}
+
+sqlite3_error sqlite3_enable_autovacuum_limit(size_t percent,
+                                              size_t max_pages) {
+    vacuum_config.percent = percent;
+    vacuum_config.max_pages = max_pages;
+
+    return sqlite3_auto_extension((void (*)())(auto_instrument_connection));
+}
+
+void sqlite3_disable_autovacuum_limit() {
+    sqlite3_cancel_auto_extension((void (*)())(auto_instrument_connection));
+}

--- a/pkg/backend/sqlite/extensions.go
+++ b/pkg/backend/sqlite/extensions.go
@@ -1,0 +1,13 @@
+package sqlite
+
+// #cgo LDFLAGS: -lsqlite3
+// #include "extensions.h"
+import "C"
+
+import "github.com/mattn/go-sqlite3"
+
+func init() {
+	if err := C.sqlite3_enable_autovacuum_limit(10, 16); err != C.SQLITE_OK {
+		panic(sqlite3.ErrNo(err))
+	}
+}

--- a/pkg/backend/sqlite/extensions.h
+++ b/pkg/backend/sqlite/extensions.h
@@ -1,0 +1,17 @@
+#include <memory.h>  // for size_t
+#include <sqlite3.h>
+#include <stdint.h>
+
+typedef int sqlite3_error;
+
+// sqlite3_enable_autovacuum_limit limits the amount of autovacuumed
+// pages to a percentage of the total database size. This is useful
+// to decide on a compromise between performance and resource usage
+//  - percent: percentage of database size to keep, so that the databse
+//    so that the databse does not need to grow again
+//  - max_pages: maximum number of pages to autovacuum
+sqlite3_error sqlite3_enable_autovacuum_limit(size_t percent, size_t max_pages);
+
+// sqlite3_disable_autovacuum_limit disables the autovacuum limit enabled
+// by @sqlite3_enable_autovacuum_limit.
+void sqlite3_disable_autovacuum_limit();


### PR DESCRIPTION
This PR enables autovacuum for small databases (which includes also new ones). This allows the database to also *shrink* other than grow. It depends on dqlite v1.8.2.

The vacuum operation is performed after every write transaction and is controlled by two parameters (tunable through [pkg/backend/sqlite/extensions.go](https://github.com/canonical/k8s-dqlite/compare/autovacuum?expand=1#diff-55c47c0eacc6d5e57226de7d9cfa150f00e516689bf07aa1b04a30fd81d82295)):
 - `max_pages` which is the maximum number of pages to remove per write transaction. This is useful to avoid creating very big transactions. I set the default to 16 (= `16 * 4KiB = 64 KiB` freed per transaction);
 - `percent` which is the percentage  (from 0 to 100) of the database to keep.

The second parameter is useful to make sure that the database doesn't do unnecessary work: it is expected that the database will continuously grow and shrink, so it is best to keep some free pages for SQLite to use. I set `10%` as the default. (Which means for example that is a database grows to `200 MiB` and then shrinks to `100 MiB` we will keep the size of the storage to `110 MiB`).

These defaults haven't been "computed" or "measured" but are what I though it would be a good default and can certainly be changed/tuned.