### PR TITLE
feat: add prefix flag to migrator backup commands

### DIFF
--- a/cmd/migrator.go
+++ b/cmd/migrator.go
@@ -10,6 +10,7 @@ var (
 	migratorCmdOpts struct {
 		endpoint string
 		mode     string
+		prefix   string
 		dbDir    string
 		debug    bool
 	}
@@ -22,6 +23,7 @@ Copy data between etcd and k8s-dqlite
 
 		k8s-dqlite migrator --mode [backup-etcd|restore-etcd|backup-dqlite|restore-dqlite] --endpoint [etcd or k8s-dqlite endpoint] --db-dir [dir to store entries]
 
+To back up only part of the key space, use the optional parameter --prefix /registry/...
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			if migratorCmdOpts.debug {
@@ -30,10 +32,10 @@ Copy data between etcd and k8s-dqlite
 
 			ctx := cmd.Context()
 
-			logrus.WithFields(logrus.Fields{"mode": migratorCmdOpts.mode, "endpoint": migratorCmdOpts.endpoint, "dir": migratorCmdOpts.dbDir}).Print("starting migrator")
+			logrus.WithFields(logrus.Fields{"mode": migratorCmdOpts.mode, "endpoint": migratorCmdOpts.endpoint, "prefix": migratorCmdOpts.prefix, "dir": migratorCmdOpts.dbDir}).Print("starting migrator")
 			switch migratorCmdOpts.mode {
 			case "backup", "backup-etcd":
-				if err := migrator.BackupEtcd(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.dbDir); err != nil {
+				if err := migrator.BackupEtcdPrefix(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.prefix, migratorCmdOpts.dbDir); err != nil {
 					logrus.WithError(err).Fatal("failed to backup etcd")
 				}
 			case "restore", "restore-to-dqlite", "restore-dqlite":
@@ -41,7 +43,7 @@ Copy data between etcd and k8s-dqlite
 					logrus.WithError(err).Fatal("failed to restore to etcd")
 				}
 			case "backup-dqlite":
-				if err := migrator.BackupDqlite(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.dbDir); err != nil {
+				if err := migrator.BackupDqlitePrefix(ctx, migratorCmdOpts.endpoint, migratorCmdOpts.prefix, migratorCmdOpts.dbDir); err != nil {
 					logrus.WithError(err).Fatal("failed to backup dqlite")
 				}
 			case "restore-to-etcd", "restore-etcd":
@@ -56,6 +58,7 @@ Copy data between etcd and k8s-dqlite
 func init() {
 	migratorCmd.Flags().StringVar(&migratorCmdOpts.endpoint, "endpoint", "unix:///var/snap/microk8s/current/var/kubernetes/backend/kine.sock", "")
 	migratorCmd.Flags().StringVar(&migratorCmdOpts.mode, "mode", "backup", "")
+	migratorCmd.Flags().StringVar(&migratorCmdOpts.prefix, "prefix", "", "")
 	migratorCmd.Flags().StringVar(&migratorCmdOpts.dbDir, "db-dir", "db", "")
 	migratorCmd.Flags().BoolVar(&migratorCmdOpts.debug, "debug", false, "")
 	rootCmd.AddCommand(migratorCmd)

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -24,11 +24,18 @@ func dataFileName(dir string, index int) string {
 
 // BackupEtcd makes a back up of the contents of an etcd database into a filesystem directory.
 func BackupEtcd(ctx context.Context, endpoint, dir string) error {
+	return BackupEtcdPrefix(ctx, endpoint, "", dir)
+}
+
+// BackupEtcdPrefix makes a back up of some or all of the key space of an etcd database into a filesystem
+// directory. To back up the whole database use a prefix of "", to back up just part of the database use
+// a prefix like "/registry/secrets".
+func BackupEtcdPrefix(ctx context.Context, endpoint, prefix, dir string) error {
 	client, err := clientv3.New(clientv3.Config{Endpoints: []string{endpoint}})
 	if err != nil {
 		return fmt.Errorf("failed to create etcd client: %w", err)
 	}
-	resp, err := client.Get(ctx, "", clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
+	resp, err := client.Get(ctx, prefix, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
 	if err != nil {
 		return fmt.Errorf("failed to list keys from etcd: %w", err)
 	}
@@ -88,11 +95,23 @@ func RestoreToDqlite(ctx context.Context, endpoint, dir string) error {
 
 // BackupDqlite makes a back up of the contents of a k8s-dqlite database into a filesystem directory.
 func BackupDqlite(ctx context.Context, endpoint, dir string) error {
+	return BackupDqlitePrefix(ctx, endpoint, "", dir)
+}
+
+// BackupDqlitePrefix makes a back up of some or all of the key space of a k8s-dqlite database into a
+// filesystem directory.  To back up the whole database use a prefix of "/", to back up just part of
+// the database use a prefix like "/registry/secrets".
+func BackupDqlitePrefix(ctx context.Context, endpoint, prefix, dir string) error {
+	if prefix == "" {
+		// dqlite doesn't support an empty prefix, so use the minimal prefix "/"
+		// that is a prefix of all valid k8s keys
+		prefix = "/"
+	}
 	client, err := client.New(k8s_dqlite_endpoint.ETCDConfig{Endpoints: []string{endpoint}})
 	if err != nil {
 		return fmt.Errorf("failed to create k8s-dqlite client: %w", err)
 	}
-	resp, err := client.List(ctx, "/", 0)
+	resp, err := client.List(ctx, prefix, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list keys from dqlite: %w", err)
 	}


### PR DESCRIPTION
Add a flag to the `migrator` command to allow the user to specify a key prefix that they want to back up, rather than hard coding to always back up the entire database.  This is useful in several situations, including:

- when a user wants to back up only specific object types, e.g. to back up just their _secrets_ they could specify `--prefix /registry/secrets`
- when they have an older dqlite database created by microk8s v1.26 or earlier, and are unable to back up at all due to issue #341 - in this case passing `--prefix /registry` will allow the backup to proceed correctly.

If the new flag is _not_ supplied, the default behaviour matches the current hard-coded behaviour for backwards compatibility - an empty prefix `""` for `backup-etcd` and the prefix `"/"` for `backup-dqlite`.

### Thank you for making K8s-dqlite better

*Verify you have:*

* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
