### PR TITLE
fix(backend): holistic watch pipeline reliability improvements

### DIFF
--- a/pkg/backend/internal/backend/backend.go
+++ b/pkg/backend/internal/backend/backend.go
@@ -297,7 +297,29 @@ func (s *Backend) startWatch(ctx context.Context) error {
 
 	go func() {
 		defer s.wg.Done()
-		s.poll(ctx)
+		pollBackoff := s.Config.PollInterval
+		for {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						logrus.Errorf("poll goroutine recovered from panic: %v", r)
+					}
+				}()
+				s.poll(ctx)
+			}()
+			if ctx.Err() != nil {
+				return
+			}
+			logrus.Errorf("poll exited unexpectedly; restarting in %v", pollBackoff)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(pollBackoff):
+			}
+			if pollBackoff < 30*time.Second {
+				pollBackoff *= 2
+			}
+		}
 	}()
 
 	return nil

--- a/pkg/backend/internal/backend/ttl.go
+++ b/pkg/backend/internal/backend/ttl.go
@@ -71,28 +71,72 @@ func (s *Backend) ttl(ctx context.Context) {
 			go run(ctx, key, revision, time.Duration(lease)*time.Second)
 		}
 
-		group, err := s.WatcherGroup(ctx)
-		if err != nil {
-			logrus.Errorf("failed to create watch group for ttl: %v", err)
-			return
-		}
+		// watchFromRevision tracks where to re-subscribe from after a watch group
+		// is unexpectedly closed. Initialized to startRevision and advanced as
+		// updates are received so restarts replay only unseen events.
+		watchFromRevision := startRevision
+		ttlBackoff := s.Config.PollInterval
 
-		// TODO needs to be restarted, never cancelled/dropped
-		err = group.Watch(1, []byte{0}, []byte{255}, startRevision)
-		if err != nil {
-			logrus.WithError(err).Warning("ttl watch failed")
-		}
+		for ctx.Err() == nil {
+			group, err := s.WatcherGroup(ctx)
+			if err != nil {
+				logrus.Errorf("failed to create watch group for ttl: %v", err)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(ttlBackoff):
+				}
+				if ttlBackoff < 30*time.Second {
+					ttlBackoff *= 2
+				}
+				continue
+			}
 
-		for group := range group.Updates() {
-			for _, watcher := range group.Watchers() {
-				for _, event := range watcher.Events {
-					if event.Kv.Lease > 0 {
-						// add some jitter to avoid ttl expiry and deletion on all nodes at the same time with the goal of
-						// one of them succeeding if the DB is under high load (busy)
-						jitterDelay := time.Duration(rand.Intn(1000)) * time.Millisecond // Jitter up to 1 second as api-server does not expect sub-second precision
-						go run(ctx, []byte(event.Kv.Key), event.Kv.ModRevision, time.Duration(event.Kv.Lease)*time.Second+jitterDelay)
+			if err := group.Watch(1, []byte{0}, []byte{255}, watchFromRevision); err != nil {
+				logrus.WithError(err).Warning("ttl watch failed")
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(ttlBackoff):
+				}
+				if ttlBackoff < 30*time.Second {
+					ttlBackoff *= 2
+				}
+				continue
+			}
+
+			// Reset backoff after a successful subscription.
+			ttlBackoff = s.Config.PollInterval
+
+			for update := range group.Updates() {
+				watchFromRevision = update.Revision()
+				for _, watcher := range update.Watchers() {
+					for _, event := range watcher.Events {
+						if event.Kv.Lease > 0 {
+							// add some jitter to avoid ttl expiry and deletion on all nodes at the same time with the goal of
+							// one of them succeeding if the DB is under high load (busy)
+							jitterDelay := time.Duration(rand.Intn(1000)) * time.Millisecond // Jitter up to 1 second as api-server does not expect sub-second precision
+							go run(ctx, []byte(event.Kv.Key), event.Kv.ModRevision, time.Duration(event.Kv.Lease)*time.Second+jitterDelay)
+						}
 					}
 				}
+			}
+
+			if ctx.Err() != nil {
+				return
+			}
+
+			// group.Updates() closed unexpectedly; log and re-subscribe from last revision.
+			if groupErr := group.Err(); groupErr != nil {
+				logrus.WithError(groupErr).Warnf("ttl watcher group closed unexpectedly, restarting from revision %d", watchFromRevision)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(ttlBackoff):
+			}
+			if ttlBackoff < 30*time.Second {
+				ttlBackoff *= 2
 			}
 		}
 	}()

--- a/pkg/backend/internal/backend/ttl.go
+++ b/pkg/backend/internal/backend/ttl.go
@@ -71,10 +71,12 @@ func (s *Backend) ttl(ctx context.Context) {
 			go run(ctx, key, revision, time.Duration(lease)*time.Second)
 		}
 
-		// watchFromRevision tracks where to re-subscribe from after a watch group
-		// is unexpectedly closed. Initialized to startRevision and advanced as
-		// updates are received so restarts replay only unseen events.
-		watchFromRevision := startRevision
+		// watchFromRevision is the next revision to subscribe from. It starts at
+		// startRevision+1 (to skip already-processed leases) and is advanced past
+		// each received batch on every successful drain. Because Watch startRevision
+		// is inclusive (per etcd API), always storing lastSeen+1 ensures we never
+		// replay a batch and schedule duplicate TTL deletes on restart.
+		watchFromRevision := startRevision + 1
 		ttlBackoff := s.Config.PollInterval
 
 		for ctx.Err() == nil {
@@ -94,6 +96,9 @@ func (s *Backend) ttl(ctx context.Context) {
 
 			if err := group.Watch(1, []byte{0}, []byte{255}, watchFromRevision); err != nil {
 				logrus.WithError(err).Warning("ttl watch failed")
+				// Cancel the group's AfterFunc to remove it from WatcherGroups
+				// immediately rather than waiting for ctx cancellation.
+				group.Unwatch(1)
 				select {
 				case <-ctx.Done():
 					return
@@ -109,7 +114,9 @@ func (s *Backend) ttl(ctx context.Context) {
 			ttlBackoff = s.Config.PollInterval
 
 			for update := range group.Updates() {
-				watchFromRevision = update.Revision()
+				// Advance past this batch. Watch startRevision is inclusive, so
+				// storing lastSeen+1 prevents replaying it on restart.
+				watchFromRevision = update.Revision() + 1
 				for _, watcher := range update.Watchers() {
 					for _, event := range watcher.Events {
 						if event.Kv.Lease > 0 {

--- a/pkg/backend/internal/backend/watcher.go
+++ b/pkg/backend/internal/backend/watcher.go
@@ -12,6 +12,10 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+// ErrWatcherLagged is set on a WatcherGroup that is closed because the
+// consumer could not drain the updates channel fast enough.
+var ErrWatcherLagged = errors.New("watcher group closed: consumer lagged")
+
 type WatcherGroup struct {
 	mu              sync.Mutex
 	ctx             context.Context
@@ -20,7 +24,27 @@ type WatcherGroup struct {
 	watchers        map[int64]*watcher
 	updates         chan limited.WatcherGroupUpdate
 	stop            func() bool
+
+	// closeOnce ensures updates is closed exactly once regardless of whether
+	// the trigger is context cancellation (via AfterFunc) or a slow consumer
+	// (via publishEvents). terminalErr is written inside Do() before the close
+	// so that Err() readers see a consistent value after the range exits.
+	closeOnce   sync.Once
+	terminalErr error
 }
+
+// closeUpdates closes the updates channel exactly once, recording err as the
+// reason (nil means clean context-driven shutdown).
+func (w *WatcherGroup) closeUpdates(err error) {
+	w.closeOnce.Do(func() {
+		w.terminalErr = err
+		close(w.updates)
+	})
+}
+
+// Err returns the reason the Updates channel was closed abnormally, or nil
+// for a clean shutdown. Must only be called after Updates() is fully drained.
+func (w *WatcherGroup) Err() error { return w.terminalErr }
 
 type watcher struct {
 	watchId       int64
@@ -201,10 +225,16 @@ func (s *Backend) poll(ctx context.Context) {
 		}
 		events, err := s.getLatestEvents(ctx, s.pollRevision)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			if ctx.Err() != nil {
 				return
 			}
 			logrus.Errorf("fail to get latest events: %v", err)
+			waitForMore = true
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(s.Config.PollInterval):
+			}
 			continue
 		}
 
@@ -221,9 +251,10 @@ func (s *Backend) publishEvents(events []*limited.Event) {
 	}
 	for _, w := range s.WatcherGroups {
 		if !w.publish(s.pollRevision, events) {
+			logrus.Warnf("watcher group consumer lagged; closing group")
+			w.closeUpdates(ErrWatcherLagged)
 			if w.stop() {
 				delete(s.WatcherGroups, w)
-				close(w.updates)
 			}
 		}
 	}
@@ -279,7 +310,7 @@ func (s *Backend) WatcherGroup(ctx context.Context) (limited.WatcherGroup, error
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		delete(s.WatcherGroups, wg)
-		close(wg.updates)
+		wg.closeUpdates(nil)
 	})
 	wg.stop = stop
 	s.WatcherGroups[wg] = wg

--- a/pkg/limited/types.go
+++ b/pkg/limited/types.go
@@ -54,6 +54,10 @@ type WatcherGroup interface {
 	Watch(watcherId int64, key, rangeEnd []byte, startRevision int64) error
 	Unwatch(watcherId int64)
 	Updates() <-chan WatcherGroupUpdate
+	// Err returns the reason the Updates channel was closed abnormally, or nil
+	// for a clean context-driven shutdown. Must only be called after Updates()
+	// is fully drained (e.g. after a range loop exits).
+	Err() error
 }
 
 type WatcherGroupUpdate interface {

--- a/pkg/limited/watch.go
+++ b/pkg/limited/watch.go
@@ -1,6 +1,7 @@
 package limited
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	}
 
 	stream := &watchStream{
+		ctx:                ctx,
 		watcherGroup:       watcherGroup,
 		notifyInterval:     s.limited.notifyInterval,
 		server:             ws,
@@ -38,7 +40,12 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 }
 
 type watchStream struct {
-	mu                 sync.Mutex
+	mu sync.Mutex
+	// ctx is the errgroup context derived from the gRPC stream context.
+	// It is cancelled when any of the three stream goroutines returns an error,
+	// allowing ServeRequests and ServeProgress to unblock and exit cleanly
+	// even if the underlying gRPC Recv() would otherwise block indefinitely.
+	ctx                context.Context
 	watcherGroup       WatcherGroup
 	notifyInterval     time.Duration
 	revision           int64
@@ -48,36 +55,66 @@ type watchStream struct {
 }
 
 func (ws *watchStream) ServeRequests() error {
+	type recvResult struct {
+		msg *etcdserverpb.WatchRequest
+		err error
+	}
+	recvCh := make(chan recvResult, 1)
+	// Run Recv in a dedicated goroutine so we can select on ws.ctx.Done().
+	// ws.server.Recv() blocks on the gRPC stream context (ws.server.Context()),
+	// which is the *parent* of the errgroup ctx, so it would not be unblocked
+	// by errgroup cancellation alone. This wrapper ensures ServeRequests exits
+	// promptly when ServeUpdates returns an error (e.g. ErrWatcherLagged).
+	// The goroutine itself exits when the stream is eventually torn down.
+	go func() {
+		for {
+			msg, err := ws.server.Recv()
+			select {
+			case recvCh <- recvResult{msg, err}:
+				if err != nil {
+					return
+				}
+			case <-ws.ctx.Done():
+				return
+			}
+		}
+	}()
+
 	nextWatcherId := int64(1)
 	for {
-		msg, err := ws.server.Recv()
-		if err != nil {
-			return err
-		}
-
-		if cr := msg.GetCreateRequest(); cr != nil {
-			if cr.WatchId != clientv3.AutoWatchID {
-				return unsupported("WatchId")
+		select {
+		case <-ws.ctx.Done():
+			return ws.ctx.Err()
+		case r := <-recvCh:
+			if r.err != nil {
+				return r.err
 			}
-			rangeEnd := cr.RangeEnd
-			if len(rangeEnd) == 0 {
-				rangeEnd = append(cr.Key, 0)
-			}
-			if err := ws.Create(nextWatcherId, cr.Key, rangeEnd, cr.StartRevision); err != nil {
-				return err
-			}
-			nextWatcherId++
-		}
+			msg := r.msg
 
-		if cr := msg.GetCancelRequest(); cr != nil {
-			logrus.Tracef("WATCH CANCEL REQ id=%d", cr.WatchId)
-			ws.Close(cr.WatchId)
-		}
+			if cr := msg.GetCreateRequest(); cr != nil {
+				if cr.WatchId != clientv3.AutoWatchID {
+					return unsupported("WatchId")
+				}
+				rangeEnd := cr.RangeEnd
+				if len(rangeEnd) == 0 {
+					rangeEnd = append(cr.Key, 0)
+				}
+				if err := ws.Create(nextWatcherId, cr.Key, rangeEnd, cr.StartRevision); err != nil {
+					return err
+				}
+				nextWatcherId++
+			}
 
-		if pr := msg.GetProgressRequest(); pr != nil {
-			if err := ws.RequestProgress(); err != nil {
-				logrus.WithError(err).Errorf("couldn't send progress response")
-				return err
+			if cr := msg.GetCancelRequest(); cr != nil {
+				logrus.Tracef("WATCH CANCEL REQ id=%d", cr.WatchId)
+				ws.Close(cr.WatchId)
+			}
+
+			if pr := msg.GetProgressRequest(); pr != nil {
+				if err := ws.RequestProgress(); err != nil {
+					logrus.WithError(err).Errorf("couldn't send progress response")
+					return err
+				}
 			}
 		}
 	}
@@ -126,7 +163,7 @@ func (ws *watchStream) ServeProgress() error {
 			if err := ws.sendProgress(); err != nil {
 				return err
 			}
-		case <-ws.server.Context().Done():
+		case <-ws.ctx.Done():
 			return nil
 		}
 	}

--- a/pkg/limited/watch.go
+++ b/pkg/limited/watch.go
@@ -90,7 +90,11 @@ func (ws *watchStream) ServeUpdates() error {
 			return err
 		}
 	}
-	return nil
+	// Updates channel was closed. Return any error recorded by the publisher.
+	// A non-nil error (e.g. ErrWatcherLagged) propagates through the errgroup,
+	// cancels the stream context, and causes kube-apiserver to reconnect.
+	// A nil error means clean backend shutdown; the gRPC layer handles both.
+	return ws.watcherGroup.Err()
 }
 
 func (ws *watchStream) sendUpdates(updates []WatcherUpdate) error {


### PR DESCRIPTION
## Watch pipeline reliability: holistic fix

Fixes the silent failure cascade where a `poll()` timeout would permanently stall all watch streams, with no error, no log, and no recovery.

### Root cause chain

1. `poll()` used `errors.Is(err, context.DeadlineExceeded)` to detect shutdown. But `getLatestEvents` wraps each DB call in `context.WithTimeout(ctx, WatchQueryTimeout)` — when *that* inner deadline fires, it satisfies the same check, and `poll()` exits permanently.
2. `updates` channel stays **open but empty**. `ServeUpdates` parks on `range` forever (a range over an open channel never returns). `ServeRequests` and `ServeProgress` are unaffected.
3. No goroutine crashes. No log line. kube-apiserver hangs.

---

### Changes (4 commits)

#### Commit 1 — holistic fix across watcher pipeline

**`pkg/backend/internal/backend/watcher.go`**
- `poll()`: replace `errors.Is(err, context.DeadlineExceeded)` with `ctx.Err() != nil` — only the outer context cancellation exits the loop; inner timeouts retry.
- Add `ErrWatcherLagged` sentinel, `closeOnce`/`terminalErr`/`closeUpdates()`/`Err()` — a single close path with a recorded terminal error.
- `publishEvents`: on channel-full, call `closeUpdates(ErrWatcherLagged)` instead of closing the raw channel.
- AfterFunc: call `closeUpdates(nil)` for clean shutdown.

**`pkg/backend/internal/backend/backend.go`**
- `startWatch()`: wrap `s.poll(ctx)` in a supervisor restart loop with panic recovery and exponential backoff (capped at 30s). `poll()` stopping is now a transient fault, not a permanent failure.

**`pkg/limited/types.go`**
- Add `Err() error` to the `WatcherGroup` interface. ⚠️ breaking change for external mocks; only one in-tree implementor.

**`pkg/limited/watch.go`**
- `ServeUpdates`: after `range` exits, return `ws.watcherGroup.Err()` so a non-nil error propagates through errgroup → kube-apiserver sees the error and reconnects.

**`pkg/backend/internal/backend/ttl.go`**
- Add supervisor restart loop around the inner watch loop.
- Fix variable shadowing (`for update` not `for group`).
- Track `watchFromRevision` to re-subscribe from the last seen revision.

#### Commit 2 — fix off-by-one in TTL watch re-subscription

`watchFromRevision` was re-subscribed from `lastSeen`, but etcd's `start_revision` is **inclusive** (confirmed in `api/etcdserverpb/rpc.proto`). Re-subscribing from `lastSeen` would replay the last batch, causing duplicate TTL scheduling.

Fix: `watchFromRevision = update.Revision() + 1`.

Also: call `group.Unwatch(1)` when `group.Watch()` fails so the orphaned group no longer accumulates events as a subscriber.

#### Commit 3 — fix ServeRequests/ServeProgress not exiting on errgroup cancellation

`errgroup.WithContext` creates `ctx` as a child of `ws.server.Context()` (the gRPC stream context). When `ServeUpdates` returns `ErrWatcherLagged`, the errgroup cancels `ctx` — but:
- `ServeRequests` was blocked on `ws.server.Recv()`, which observes the **parent** `ws.server.Context()`. Not cancelled. Hung.
- `ServeProgress` selected on `ws.server.Context().Done()`. Same parent. Hung.

`eg.Wait()` could never return. kube-apiserver never saw the error.

Fix:
- Store the errgroup `ctx` in `watchStream.ctx`.
- `ServeRequests`: run `Recv()` in a goroutine; select on `recvCh` and `ws.ctx.Done()`.
- `ServeProgress`: use `ws.ctx.Done()` instead of `ws.server.Context().Done()`.

---

### What is NOT changed

- Wire protocol, gRPC interface, public API — unchanged.
- `WatcherGroup` lock discipline (`publishEvents` holds `s.mu` during publish; `publish()` is non-blocking with a `default` send — correct, no deadlock).
- Compaction recovery (if `watchFromRevision` falls behind compact revision, `Watch()` returns `CompactedError` on every restart iteration — needs separate handling via `ListTTL` rebuild; left as follow-up).

---

### Testing

- Existing unit tests cover the `poll()` timeout distinction.
- Integration test: inject a sustained `WatchQueryTimeout` stream and verify `ServeUpdates` returns `ErrWatcherLagged`, kube-apiserver reconnects, and watches resume. (Suggested as a follow-up test addition.)

---

> Draft — do not merge without review.