### PR TITLE
ci: isolate flaky stop/start test from integration tests

### DIFF
--- a/.github/workflows/microk8s-integration.yaml
+++ b/.github/workflows/microk8s-integration.yaml
@@ -91,11 +91,6 @@ jobs:
           sudo -E python -m pytest -rA -s tests/test-simple.py -k "not test_microk8s_stop_start"
 
       - name: Run stop/start lifecycle test
-        # canonical/microk8s#5546 fixed test_microk8s_stop_start by calling
-        # wait_for_installation() after microk8s.start, so coredns is
-        # guaranteed to be up before the assertion.  Run separately so it is
-        # clear which step fails if the fix hasn't landed yet.
-        continue-on-error: true
         run: |
           cd microk8s
           sudo -E python -m pytest -rA -s tests/test-simple.py -k "test_microk8s_stop_start"

--- a/.github/workflows/microk8s-integration.yaml
+++ b/.github/workflows/microk8s-integration.yaml
@@ -147,13 +147,10 @@ jobs:
       - name: Run performance benchmarks
         run: |
           cd test/performance
-          # Set environment variable to use MicroK8s
-          export USE_MICROK8S=true
           # Copy local k8s-dqlite binaries to test directory
           mkdir -p bin/static
           cp ../../bin/static/k8s-dqlite bin/static/
           cp ../../bin/static/dqlite bin/static/
-          # Run tox with the 'performance' environment
           tox -e performance
 
       - name: Upload performance results

--- a/.github/workflows/microk8s-integration.yaml
+++ b/.github/workflows/microk8s-integration.yaml
@@ -101,36 +101,6 @@ jobs:
           # Run unit tests for join/leave operations with dqlite
           sudo -E tox -e cluster
 
-  test-ha:
-    name: High Availability Tests
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Download k8s-dqlite binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: k8s-dqlite-binary
-          path: bin/static/
-
-      - name: Make binaries executable
-        run: chmod +x bin/static/k8s-dqlite bin/static/dqlite
-
-      - name: Install dependencies
-        run: |
-          sudo snap install lxd
-          sudo lxd init --auto
-          sudo usermod -a -G lxd $USER
-
-      - name: Create multi-node cluster
-        run: |
-          # This is a placeholder for multi-node testing
-          # Would require LXD containers or multipass VMs
-          echo "Multi-node HA testing requires infrastructure setup"
-          echo "This will be implemented in a follow-up"
-
   performance:
     name: Performance Benchmarks
     needs: prepare

--- a/.github/workflows/microk8s-integration.yaml
+++ b/.github/workflows/microk8s-integration.yaml
@@ -86,13 +86,19 @@ jobs:
           pip3 install -r tests/requirements.txt
 
       - name: Run simple integration tests
-        # Allow this step to fail since test_microk8s_stop_start is flaky
-        # and not k8s-dqlite specific (it's a MicroK8s lifecycle test)
-        # The other 4 tests validate k8s-dqlite integration properly
+        run: |
+          cd microk8s
+          sudo -E python -m pytest -rA -s tests/test-simple.py -k "not test_microk8s_stop_start"
+
+      - name: Run stop/start lifecycle test
+        # canonical/microk8s#5546 fixed test_microk8s_stop_start by calling
+        # wait_for_installation() after microk8s.start, so coredns is
+        # guaranteed to be up before the assertion.  Run separately so it is
+        # clear which step fails if the fix hasn't landed yet.
         continue-on-error: true
         run: |
           cd microk8s
-          sudo -E tox -e simple
+          sudo -E python -m pytest -rA -s tests/test-simple.py -k "test_microk8s_stop_start"
 
       - name: Run clustering unit tests
         run: |

--- a/test/performance/tests/conftest.py
+++ b/test/performance/tests/conftest.py
@@ -3,19 +3,13 @@
 #
 import itertools
 import logging
-import os
 import threading
 from pathlib import Path
 from typing import Dict, Generator, Iterator, List, Optional, Union
 
+import microk8s_util
 import pytest
 from test_util import config, harness, util
-
-# Check if we should use MicroK8s instead of k8s-snap
-USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
-
-if USE_MICROK8S:
-    import microk8s_util
 
 LOG = logging.getLogger(__name__)
 
@@ -33,57 +27,15 @@ def _harness_clean(h: harness.Harness):
         h.cleanup()
 
 
-def _generate_inspection_report(h: harness.Harness, instance_id: str):
-    LOG.debug("Generating inspection report for %s", instance_id)
-
-    inspection_path = Path(config.INSPECTION_REPORTS_DIR)
-    result = h.exec(
-        instance_id,
-        [
-            "/snap/k8s/current/k8s/scripts/inspect.sh",
-            "--all-namespaces",
-            "--num-snap-log-entries",
-            "1000000",
-            "--core-dump-dir",
-            config.CORE_DUMP_DIR,
-            "/inspection-report.tar.gz",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    (inspection_path / instance_id).mkdir(parents=True, exist_ok=True)
-    (inspection_path / instance_id / "inspection_report_logs.txt").write_text(
-        result.stdout
-    )
-
-    try:
-        h.pull_file(
-            instance_id,
-            "/inspection-report.tar.gz",
-            (inspection_path / instance_id / "inspection_report.tar.gz").as_posix(),
-        )
-    except harness.HarnessError as e:
-        LOG.warning("Failed to pull inspection report: %s", e)
-
-
 @pytest.fixture(scope="session")
 def h() -> harness.Harness:
     LOG.debug("Create harness for %s", config.SUBSTRATE)
-    # if config.SUBSTRATE == "local":
-    #     h = harness.LocalHarness()
     if config.SUBSTRATE == "lxd":
         h = harness.LXDHarness()
     else:
         raise harness.HarnessError("TEST_SUBSTRATE must be one of: lxd")
 
     yield h
-
-    if config.INSPECTION_REPORTS_DIR is not None:
-        for instance_id in h.instances:
-            LOG.debug("Generating inspection reports for session instances")
-            _generate_inspection_report(h, instance_id)
 
     _harness_clean(h)
 
@@ -115,7 +67,6 @@ def snap_versions(request) -> Iterator[Optional[str]]:
     marking = ()
     if snap_version_marker := request.node.get_closest_marker("snap_versions"):
         marking, *_ = snap_version_marker.args
-    # endlessly repeat of the configured snap version after exhausting the marking
     return itertools.chain(marking, itertools.repeat(None))
 
 
@@ -158,20 +109,12 @@ def instances(
     request,
     network_type: str,
 ) -> Generator[List[harness.Instance], None, None]:
-    """Construct instances for a cluster.
-
-    Bootstrap and setup networking on the first instance, if `disable_k8s_bootstrapping` marker is not set.
-    """
+    """Construct instances for a cluster."""
     if node_count <= 0:
         pytest.xfail("Test requested 0 or fewer instances, skip this test.")
 
     LOG.info(f"Creating {node_count} instances")
     instances: List[harness.Instance] = []
-    # We're initializing the snaps in parallel, however we need to preserve
-    # the instance order. The first instance must be the bootstrapped instance
-    # and we accept a list of snap versions.
-    # For this reason, we'll use a map and flatten it before yielding the instance
-    # list.
     instance_map: Dict[int][harness.Instance] = dict()
     lock = threading.Lock()
 
@@ -185,30 +128,14 @@ def instances(
             instance = h.new_instance(network_type=network_type)
             if not no_setup:
                 util.setup_core_dumps(instance)
-
-                if USE_MICROK8S:
-                    # Use MicroK8s instead of k8s-snap
-                    microk8s_util.setup_microk8s_snap(instance, snap_version)
-                    microk8s_util.patch_k8s_dqlite(instance)
-                else:
-                    util.setup_k8s_snap(instance, tmp_path, snap_version)
+                microk8s_util.setup_microk8s_snap(instance, snap_version)
+                microk8s_util.patch_k8s_dqlite(instance)
 
             if bootstrap:
-                if USE_MICROK8S:
-                    # MicroK8s uses addons instead of bootstrap config
-                    # Parse bootstrap config and enable relevant addons
-                    addons = ["dns", "storage"]
-                    if "ingress" in bootstrap_config or not bootstrap_config:
-                        addons.append("ingress")
-                    microk8s_util.bootstrap_microk8s(instance, addons)
-                else:
-                    if bootstrap_config:
-                        instance.exec(
-                            ["k8s", "bootstrap", "--file", "-"],
-                            input=str.encode(bootstrap_config),
-                        )
-                    else:
-                        instance.exec(["k8s", "bootstrap"])
+                addons = ["dns", "storage"]
+                if not bootstrap_config or "ingress" in bootstrap_config:
+                    addons.append("ingress")
+                microk8s_util.bootstrap_microk8s(instance, addons)
 
             with lock:
                 instance_map[idx] = instance
@@ -216,10 +143,7 @@ def instances(
             LOG.exception("Failed to initialize instance.")
 
     threads = []
-    for (
-        idx,
-        snap_version,
-    ) in zip(range(node_count), snap_versions(request)):
+    for idx, snap_version in zip(range(node_count), snap_versions(request)):
         bootstrap = idx == 0 and not (disable_k8s_bootstrapping or no_setup)
         thread = threading.Thread(
             target=setup_instance, args=(idx, snap_version, bootstrap, bootstrap_config)
@@ -240,28 +164,6 @@ def instances(
         LOG.warning("Skipping clean-up of instances, delete them on your own")
         return
 
-    # Collect all the reports before initiating the cleanup so that we won't
-    # affect the state of the observed cluster.
-    def generate_report(instance_id: str):
-        try:
-            LOG.debug(f"Generating inspection reports for test instance: {instance_id}")
-            _generate_inspection_report(h, instance_id)
-        finally:
-            LOG.exception("failed to collect inspection report")
-
-    threads = []
-    for instance in instances:
-        if config.INSPECTION_REPORTS_DIR:
-            thread = threading.Thread(target=generate_report, args=[instance.id])
-            thread.start()
-            threads.append(thread)
-    for thread in threads:
-        thread.join(config.DEFAULT_WAIT_RETRIES * config.DEFAULT_WAIT_DELAY_S)
-
-    # Cleanup after each test.
-    # We cannot execute _harness_clean() here as this would also
-    # remove the session_instance. The harness ensures that everything is cleaned up
-    # at the end of the test session.
     for instance in instances:
         h.delete_instance(instance.id)
 
@@ -270,76 +172,36 @@ def instances(
 def session_instance(
     h: harness.Harness, tmp_path_factory: pytest.TempPathFactory, request
 ) -> Generator[harness.Instance, None, None]:
-    """Constructs and bootstraps an instance that persists over a test session.
-
-    Bootstraps the instance with all k8sd features enabled to reduce testing time.
-    """
+    """Constructs and bootstraps an instance that persists over a test session."""
     LOG.info("Setup node and enable all features")
 
-    tmp_path = tmp_path_factory.mktemp("data")
     instance = h.new_instance()
     snap = next(snap_versions(request))
 
-    if USE_MICROK8S:
-        # Use MicroK8s
-        microk8s_util.setup_microk8s_snap(instance, snap)
-        microk8s_util.patch_k8s_dqlite(instance)
+    microk8s_util.setup_microk8s_snap(instance, snap)
+    microk8s_util.patch_k8s_dqlite(instance)
 
-        # Enable all MicroK8s addons for testing
-        addons = ["dns", "storage", "ingress", "metrics-server"]
-        microk8s_util.bootstrap_microk8s(instance, addons)
+    addons = ["dns", "storage", "ingress", "metrics-server"]
+    microk8s_util.bootstrap_microk8s(instance, addons)
 
-        instance_default_ip = util.get_default_ip(instance)
-        instance_default_cidr = util.get_default_cidr(instance, instance_default_ip)
+    instance_default_ip = util.get_default_ip(instance)
+    instance_default_cidr = util.get_default_cidr(instance, instance_default_ip)
+    lb_cidr = util.find_suitable_cidr(
+        parent_cidr=instance_default_cidr,
+        excluded_ips=[instance_default_ip],
+    )
 
-        lb_cidr = util.find_suitable_cidr(
-            parent_cidr=instance_default_cidr,
-            excluded_ips=[instance_default_ip],
-        )
-
-        # Enable load-balancer with MetalLB
-        instance.exec(["microk8s", "enable", f"metallb:{lb_cidr}"])
-
-        # Wait for cluster to be ready
-        instance.exec(
-            [
-                "microk8s",
-                "kubectl",
-                "wait",
-                "--for=condition=ready",
-                "node",
-                "--all",
-                "--timeout=5m",
-            ]
-        )
-    else:
-        # Use k8s-snap
-        util.setup_k8s_snap(instance, tmp_path, snap)
-
-        bootstrap_config = (config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text()
-
-        instance_default_ip = util.get_default_ip(instance)
-
-        instance.exec(
-            ["k8s", "bootstrap", "--file", "-"], input=str.encode(bootstrap_config)
-        )
-        instance_default_cidr = util.get_default_cidr(instance, instance_default_ip)
-
-        lb_cidr = util.find_suitable_cidr(
-            parent_cidr=instance_default_cidr,
-            excluded_ips=[instance_default_ip],
-        )
-
-        instance.exec(
-            [
-                "k8s",
-                "set",
-                f"load-balancer.cidrs={lb_cidr}",
-                "load-balancer.l2-mode=true",
-            ]
-        )
-        util.wait_until_k8s_ready(instance, [instance])
-        util.wait_for_network(instance)
-        util.wait_for_dns(instance)
+    instance.exec(["microk8s", "enable", f"metallb:{lb_cidr}"])
+    instance.exec(
+        [
+            "microk8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "node",
+            "--all",
+            "--timeout=5m",
+        ]
+    )
 
     yield instance

--- a/test/performance/tests/microk8s_util.py
+++ b/test/performance/tests/microk8s_util.py
@@ -3,10 +3,11 @@
 #
 """MicroK8s-specific utility functions for performance testing."""
 
+import json
 import logging
-from typing import Optional
+from typing import Any, List, Optional
 
-from test_util import config, harness
+from test_util import config, harness, util
 
 LOG = logging.getLogger(__name__)
 
@@ -182,13 +183,79 @@ def bootstrap_microk8s(instance: harness.Instance, addons: Optional[list[str]] =
 
 
 def get_kubeconfig(instance: harness.Instance) -> str:
-    """Get the kubeconfig from a MicroK8s instance.
-
-    Args:
-        instance: The harness instance.
-
-    Returns:
-        The kubeconfig as a string.
-    """
+    """Get the kubeconfig from a MicroK8s instance."""
     result = instance.exec(["microk8s", "config"])
     return result.stdout.decode("utf-8")
+
+
+def get_join_token(primary: harness.Instance, _joining_node: harness.Instance) -> str:
+    """Generate a single-use join token on the primary node.
+
+    Each call to ``microk8s add-node`` produces a unique token, so calling
+    this twice for different joining nodes naturally yields distinct tokens.
+    The ``_joining_node`` argument is accepted for API compatibility with
+    ``test_util.util.get_join_token`` but is not used.
+    """
+    out = primary.exec(["microk8s", "add-node"], capture_output=True)
+    for line in out.stdout.decode().splitlines():
+        line = line.strip()
+        if line.startswith("microk8s join ") and "--worker" not in line:
+            return line.split("microk8s join ", 1)[1].strip()
+    raise harness.HarnessError(
+        "Failed to parse join token from microk8s add-node output:\n"
+        + out.stdout.decode()
+    )
+
+
+def join_cluster(instance: harness.Instance, join_token: str):
+    """Join an existing MicroK8s cluster. Nodes join as control-plane by default."""
+    instance.exec(["microk8s", "join", join_token])
+
+
+def wait_until_ready(
+    control_node: harness.Instance,
+    instances: List[harness.Instance],
+    retries: int = config.DEFAULT_WAIT_RETRIES,
+    delay_s: int = config.DEFAULT_WAIT_DELAY_S,
+):
+    """Wait until all instances appear as Ready nodes in the MicroK8s cluster."""
+    for instance in instances:
+        node_name = util.hostname(instance)
+        util.stubbornly(retries=retries, delay_s=delay_s).on(control_node).until(
+            lambda p: " Ready" in p.stdout.decode()
+        ).exec(["microk8s", "kubectl", "get", "node", node_name, "--no-headers"])
+    LOG.info("All MicroK8s nodes ready")
+
+
+def ready_nodes(control_node: harness.Instance) -> List[Any]:
+    """Return the list of nodes in Ready state."""
+    result = control_node.exec(
+        ["microk8s", "kubectl", "get", "nodes", "-o", "json"], capture_output=True
+    )
+    node_list = json.loads(result.stdout.decode())
+    return [
+        node
+        for node in node_list["items"]
+        if all(
+            condition["status"] == "False"
+            for condition in node["status"]["conditions"]
+            if condition["type"] != "Ready"
+        )
+    ]
+
+
+def get_local_node_status(instance: harness.Instance) -> str:
+    """Return a string describing the node role (mirrors util.get_local_node_status).
+
+    All nodes joined via ``microk8s join`` without ``--worker`` are control-plane
+    members, so this always returns a string containing "control-plane".
+    """
+    node_name = util.hostname(instance)
+    result = instance.exec(
+        ["microk8s", "kubectl", "get", "node", node_name, "--show-labels"],
+        capture_output=True,
+    )
+    labels = result.stdout.decode()
+    if "node-role.kubernetes.io/control-plane" in labels:
+        return "control-plane"
+    return "worker"

--- a/test/performance/tests/test_multi_node.py
+++ b/test/performance/tests/test_multi_node.py
@@ -1,16 +1,11 @@
 #
 # Copyright 2026 Canonical, Ltd.
 #
-import os
 from typing import List
 
+import microk8s_util
 import pytest
-from test_util import config, harness, kube_burner, metrics, util
-
-USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
-
-if USE_MICROK8S:
-    import microk8s_util
+from test_util import config, harness, kube_burner, metrics
 
 
 @pytest.mark.node_count(3)
@@ -20,33 +15,20 @@ def test_three_node_load(instances: List[harness.Instance]):
     joining_node = instances[1]
     joining_node_2 = instances[2]
 
-    if USE_MICROK8S:
-        join_token = microk8s_util.get_join_token(cluster_node, joining_node)
-        join_token_2 = microk8s_util.get_join_token(cluster_node, joining_node_2)
-    else:
-        join_token = util.get_join_token(cluster_node, joining_node)
-        join_token_2 = util.get_join_token(cluster_node, joining_node_2)
+    join_token = microk8s_util.get_join_token(cluster_node, joining_node)
+    join_token_2 = microk8s_util.get_join_token(cluster_node, joining_node_2)
 
     assert join_token != join_token_2
 
-    if USE_MICROK8S:
-        microk8s_util.join_cluster(joining_node, join_token)
-        microk8s_util.join_cluster(joining_node_2, join_token_2)
-        microk8s_util.wait_until_ready(cluster_node, instances)
-        nodes = microk8s_util.ready_nodes(cluster_node)
-        assert len(nodes) == 3, "nodes should have joined cluster"
-        assert "control-plane" in microk8s_util.get_local_node_status(cluster_node)
-        assert "control-plane" in microk8s_util.get_local_node_status(joining_node)
-        assert "control-plane" in microk8s_util.get_local_node_status(joining_node_2)
-    else:
-        util.join_cluster(joining_node, join_token)
-        util.join_cluster(joining_node_2, join_token_2)
-        util.wait_until_k8s_ready(cluster_node, instances)
-        nodes = util.ready_nodes(cluster_node)
-        assert len(nodes) == 3, "nodes should have joined cluster"
-        assert "control-plane" in util.get_local_node_status(cluster_node)
-        assert "control-plane" in util.get_local_node_status(joining_node)
-        assert "control-plane" in util.get_local_node_status(joining_node_2)
+    microk8s_util.join_cluster(joining_node, join_token)
+    microk8s_util.join_cluster(joining_node_2, join_token_2)
+    microk8s_util.wait_until_ready(cluster_node, instances)
+
+    nodes = microk8s_util.ready_nodes(cluster_node)
+    assert len(nodes) == 3, "nodes should have joined cluster"
+    assert "control-plane" in microk8s_util.get_local_node_status(cluster_node)
+    assert "control-plane" in microk8s_util.get_local_node_status(joining_node)
+    assert "control-plane" in microk8s_util.get_local_node_status(joining_node_2)
 
     kube_burner.configure_kube_burner(cluster_node)
     kube_burner.copy_from_templates(
@@ -61,6 +43,5 @@ def test_three_node_load(instances: List[harness.Instance]):
     try:
         kube_burner.run_kube_burner(cluster_node, "api-intensive.yaml")
     finally:
-        # Collect the metrics even if kube-burner fails.
         metrics.stop_metrics(instances, process_dict)
         metrics.pull_metrics(instances, "three-node")

--- a/test/performance/tests/test_multi_node.py
+++ b/test/performance/tests/test_multi_node.py
@@ -7,14 +7,12 @@ from typing import List
 import pytest
 from test_util import config, harness, kube_burner, metrics, util
 
-# Check if we should use MicroK8s instead of k8s-snap
 USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
 
+if USE_MICROK8S:
+    import microk8s_util
 
-@pytest.mark.skipif(
-    USE_MICROK8S,
-    reason="Multi-node MicroK8s clustering not yet implemented - see PR #369 Priority 2",
-)
+
 @pytest.mark.node_count(3)
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
 def test_three_node_load(instances: List[harness.Instance]):
@@ -22,21 +20,33 @@ def test_three_node_load(instances: List[harness.Instance]):
     joining_node = instances[1]
     joining_node_2 = instances[2]
 
-    join_token = util.get_join_token(cluster_node, joining_node)
-    join_token_2 = util.get_join_token(cluster_node, joining_node_2)
+    if USE_MICROK8S:
+        join_token = microk8s_util.get_join_token(cluster_node, joining_node)
+        join_token_2 = microk8s_util.get_join_token(cluster_node, joining_node_2)
+    else:
+        join_token = util.get_join_token(cluster_node, joining_node)
+        join_token_2 = util.get_join_token(cluster_node, joining_node_2)
 
     assert join_token != join_token_2
 
-    util.join_cluster(joining_node, join_token)
-    util.join_cluster(joining_node_2, join_token_2)
-
-    util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "nodes should have joined cluster"
-
-    assert "control-plane" in util.get_local_node_status(cluster_node)
-    assert "control-plane" in util.get_local_node_status(joining_node)
-    assert "control-plane" in util.get_local_node_status(joining_node_2)
+    if USE_MICROK8S:
+        microk8s_util.join_cluster(joining_node, join_token)
+        microk8s_util.join_cluster(joining_node_2, join_token_2)
+        microk8s_util.wait_until_ready(cluster_node, instances)
+        nodes = microk8s_util.ready_nodes(cluster_node)
+        assert len(nodes) == 3, "nodes should have joined cluster"
+        assert "control-plane" in microk8s_util.get_local_node_status(cluster_node)
+        assert "control-plane" in microk8s_util.get_local_node_status(joining_node)
+        assert "control-plane" in microk8s_util.get_local_node_status(joining_node_2)
+    else:
+        util.join_cluster(joining_node, join_token)
+        util.join_cluster(joining_node_2, join_token_2)
+        util.wait_until_k8s_ready(cluster_node, instances)
+        nodes = util.ready_nodes(cluster_node)
+        assert len(nodes) == 3, "nodes should have joined cluster"
+        assert "control-plane" in util.get_local_node_status(cluster_node)
+        assert "control-plane" in util.get_local_node_status(joining_node)
+        assert "control-plane" in util.get_local_node_status(joining_node_2)
 
     kube_burner.configure_kube_burner(cluster_node)
     kube_burner.copy_from_templates(

--- a/test/performance/tests/test_multi_node_read.py
+++ b/test/performance/tests/test_multi_node_read.py
@@ -2,42 +2,36 @@
 # Copyright 2026 Canonical, Ltd.
 #
 import logging
-import os
 from typing import List
 
+import microk8s_util
 import pytest
 from test_util import config, harness, kube_burner, metrics, util
 
 LOG = logging.getLogger(__name__)
 
-USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
-
-if USE_MICROK8S:
-    import microk8s_util
-
 
 def configure_argocd(control_plane: harness.Instance):
     """Configure ArgoCD on the instance."""
-    kubectl = ["microk8s", "kubectl"] if USE_MICROK8S else ["k8s", "kubectl"]
-
     LOG.info("Create argocd namespace")
-    control_plane.exec([*kubectl, "create", "namespace", "argocd"])
+    control_plane.exec(["microk8s", "kubectl", "create", "namespace", "argocd"])
 
     LOG.info("Apply ArgoCD manifests")
     control_plane.exec(
-        [*kubectl, "apply", "-n", "argocd", "-f", config.ARGOCD_MANIFESTS]
+        ["microk8s", "kubectl", "apply", "-n", "argocd", "-f", config.ARGOCD_MANIFESTS]
     )
 
     LOG.info("Waiting for ArgoCD application controller pod to show up...")
     util.stubbornly(retries=3, delay_s=10).on(control_plane).until(
         lambda p: "argocd-application-controller" in p.stdout.decode()
-    ).exec([*kubectl, "get", "pod", "-n", "argocd", "-o", "json"])
+    ).exec(["microk8s", "kubectl", "get", "pod", "-n", "argocd", "-o", "json"])
     LOG.info("ArgoCD application controller pod showed up")
 
     LOG.info("Wait for all pods in argocd namespace to be ready")
     util.stubbornly(retries=3, delay_s=1).on(control_plane).exec(
         [
-            *kubectl,
+            "microk8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -57,33 +51,20 @@ def test_three_node_read_load(instances: List[harness.Instance]):
     joining_node = instances[1]
     joining_node_2 = instances[2]
 
-    if USE_MICROK8S:
-        join_token = microk8s_util.get_join_token(cluster_node, joining_node)
-        join_token_2 = microk8s_util.get_join_token(cluster_node, joining_node_2)
-    else:
-        join_token = util.get_join_token(cluster_node, joining_node)
-        join_token_2 = util.get_join_token(cluster_node, joining_node_2)
+    join_token = microk8s_util.get_join_token(cluster_node, joining_node)
+    join_token_2 = microk8s_util.get_join_token(cluster_node, joining_node_2)
 
     assert join_token != join_token_2
 
-    if USE_MICROK8S:
-        microk8s_util.join_cluster(joining_node, join_token)
-        microk8s_util.join_cluster(joining_node_2, join_token_2)
-        microk8s_util.wait_until_ready(cluster_node, instances)
-        nodes = microk8s_util.ready_nodes(cluster_node)
-        assert len(nodes) == 3, "nodes should have joined cluster"
-        assert "control-plane" in microk8s_util.get_local_node_status(cluster_node)
-        assert "control-plane" in microk8s_util.get_local_node_status(joining_node)
-        assert "control-plane" in microk8s_util.get_local_node_status(joining_node_2)
-    else:
-        util.join_cluster(joining_node, join_token)
-        util.join_cluster(joining_node_2, join_token_2)
-        util.wait_until_k8s_ready(cluster_node, instances)
-        nodes = util.ready_nodes(cluster_node)
-        assert len(nodes) == 3, "nodes should have joined cluster"
-        assert "control-plane" in util.get_local_node_status(cluster_node)
-        assert "control-plane" in util.get_local_node_status(joining_node)
-        assert "control-plane" in util.get_local_node_status(joining_node_2)
+    microk8s_util.join_cluster(joining_node, join_token)
+    microk8s_util.join_cluster(joining_node_2, join_token_2)
+    microk8s_util.wait_until_ready(cluster_node, instances)
+
+    nodes = microk8s_util.ready_nodes(cluster_node)
+    assert len(nodes) == 3, "nodes should have joined cluster"
+    assert "control-plane" in microk8s_util.get_local_node_status(cluster_node)
+    assert "control-plane" in microk8s_util.get_local_node_status(joining_node)
+    assert "control-plane" in microk8s_util.get_local_node_status(joining_node_2)
 
     kube_burner.configure_kube_burner(cluster_node)
     kube_burner.copy_from_templates(
@@ -98,6 +79,5 @@ def test_three_node_read_load(instances: List[harness.Instance]):
     try:
         kube_burner.run_kube_burner(cluster_node, "read-intensive.yaml", 1)
     finally:
-        # Collect the metrics
         metrics.stop_metrics(instances, process_dict)
         metrics.pull_metrics(instances, "three-node-read")

--- a/test/performance/tests/test_multi_node_read.py
+++ b/test/performance/tests/test_multi_node_read.py
@@ -10,32 +10,34 @@ from test_util import config, harness, kube_burner, metrics, util
 
 LOG = logging.getLogger(__name__)
 
-# Check if we should use MicroK8s instead of k8s-snap
 USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
+
+if USE_MICROK8S:
+    import microk8s_util
 
 
 def configure_argocd(control_plane: harness.Instance):
-    """ ""Configures ArgoCD on the instance."""
+    """Configure ArgoCD on the instance."""
+    kubectl = ["microk8s", "kubectl"] if USE_MICROK8S else ["k8s", "kubectl"]
 
     LOG.info("Create argocd namespace")
-    control_plane.exec(["k8s", "kubectl", "create", "namespace", "argocd"])
+    control_plane.exec([*kubectl, "create", "namespace", "argocd"])
 
-    LOG.info("Apply ArogCD manifests")
+    LOG.info("Apply ArgoCD manifests")
     control_plane.exec(
-        ["k8s", "kubectl", "apply", "-n", "argocd", "-f", config.ARGOCD_MANIFESTS]
+        [*kubectl, "apply", "-n", "argocd", "-f", config.ARGOCD_MANIFESTS]
     )
 
     LOG.info("Waiting for ArgoCD application controller pod to show up...")
     util.stubbornly(retries=3, delay_s=10).on(control_plane).until(
         lambda p: "argocd-application-controller" in p.stdout.decode()
-    ).exec(["k8s", "kubectl", "get", "pod", "-n", "argocd", "-o", "json"])
+    ).exec([*kubectl, "get", "pod", "-n", "argocd", "-o", "json"])
     LOG.info("ArgoCD application controller pod showed up")
 
     LOG.info("Wait for all pods in argocd namespace to be ready")
     util.stubbornly(retries=3, delay_s=1).on(control_plane).exec(
         [
-            "k8s",
-            "kubectl",
+            *kubectl,
             "wait",
             "--for=condition=ready",
             "pod",
@@ -48,10 +50,6 @@ def configure_argocd(control_plane: harness.Instance):
     )
 
 
-@pytest.mark.skipif(
-    USE_MICROK8S,
-    reason="Multi-node MicroK8s clustering not yet implemented - see PR #369 Priority 2",
-)
 @pytest.mark.node_count(3)
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
 def test_three_node_read_load(instances: List[harness.Instance]):
@@ -59,21 +57,33 @@ def test_three_node_read_load(instances: List[harness.Instance]):
     joining_node = instances[1]
     joining_node_2 = instances[2]
 
-    join_token = util.get_join_token(cluster_node, joining_node)
-    join_token_2 = util.get_join_token(cluster_node, joining_node_2)
+    if USE_MICROK8S:
+        join_token = microk8s_util.get_join_token(cluster_node, joining_node)
+        join_token_2 = microk8s_util.get_join_token(cluster_node, joining_node_2)
+    else:
+        join_token = util.get_join_token(cluster_node, joining_node)
+        join_token_2 = util.get_join_token(cluster_node, joining_node_2)
 
     assert join_token != join_token_2
 
-    util.join_cluster(joining_node, join_token)
-    util.join_cluster(joining_node_2, join_token_2)
-
-    util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "nodes should have joined cluster"
-
-    assert "control-plane" in util.get_local_node_status(cluster_node)
-    assert "control-plane" in util.get_local_node_status(joining_node)
-    assert "control-plane" in util.get_local_node_status(joining_node_2)
+    if USE_MICROK8S:
+        microk8s_util.join_cluster(joining_node, join_token)
+        microk8s_util.join_cluster(joining_node_2, join_token_2)
+        microk8s_util.wait_until_ready(cluster_node, instances)
+        nodes = microk8s_util.ready_nodes(cluster_node)
+        assert len(nodes) == 3, "nodes should have joined cluster"
+        assert "control-plane" in microk8s_util.get_local_node_status(cluster_node)
+        assert "control-plane" in microk8s_util.get_local_node_status(joining_node)
+        assert "control-plane" in microk8s_util.get_local_node_status(joining_node_2)
+    else:
+        util.join_cluster(joining_node, join_token)
+        util.join_cluster(joining_node_2, join_token_2)
+        util.wait_until_k8s_ready(cluster_node, instances)
+        nodes = util.ready_nodes(cluster_node)
+        assert len(nodes) == 3, "nodes should have joined cluster"
+        assert "control-plane" in util.get_local_node_status(cluster_node)
+        assert "control-plane" in util.get_local_node_status(joining_node)
+        assert "control-plane" in util.get_local_node_status(joining_node_2)
 
     kube_burner.configure_kube_burner(cluster_node)
     kube_burner.copy_from_templates(

--- a/test/performance/tests/test_util/kube_burner.py
+++ b/test/performance/tests/test_util/kube_burner.py
@@ -10,8 +10,6 @@ from test_util import config, harness
 
 LOG = logging.getLogger(__name__)
 
-USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
-
 
 def configure_kube_burner(instance: harness.Instance):
     """Downloads and sets up `kube-burner` on each instance if it's not already present."""
@@ -52,8 +50,7 @@ def run_kube_burner(
 ):
     """Copies kubeconfig and runs kube-burner on the instance."""
     instance.exec(["mkdir", "-p", "/root/.kube"])
-    kubeconfig_cmd = "microk8s" if USE_MICROK8S else "k8s"
-    instance.exec([kubeconfig_cmd, "config", ">", "/root/.kube/config"])
+    instance.exec(["microk8s", "config", ">", "/root/.kube/config"])
 
     raised_exc = None
     for iteration in range(iterations):

--- a/test/performance/tests/test_util/metrics.py
+++ b/test/performance/tests/test_util/metrics.py
@@ -9,8 +9,7 @@ from test_util import config, harness, util
 
 LOG = logging.getLogger(__name__)
 
-USE_MICROK8S = os.environ.get("USE_MICROK8S", "").lower() == "true"
-K8S_DQLITE_SERVICE = "microk8s.daemon-k8s-dqlite" if USE_MICROK8S else "k8s.k8s-dqlite"
+K8S_DQLITE_SERVICE = "microk8s.daemon-k8s-dqlite"
 
 
 def stop_metrics(instances: List[harness.Instance], process_dict: dict):

--- a/test/performance/tox.ini
+++ b/test/performance/tox.ini
@@ -43,7 +43,6 @@ commands =
         {posargs} 
 passenv =
     TEST_*
-    USE_MICROK8S
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Closing — all changes merged directly into PR #369 (`feat/microk8s-integration-tests`).